### PR TITLE
fix: removed extra field value from threeds.areqparams in auth module

### DIFF
--- a/hyperswitch/AuthenticationViewController.swift
+++ b/hyperswitch/AuthenticationViewController.swift
@@ -271,7 +271,6 @@ class AuthenticationViewController: UIViewController {
                     statusLabel.text = """
                     -- Authentication Request Parameters Retrieved:
                     
-                    SDK Encrypted data: \(String(describing: aReqParams.sdkEncryptedData?.prefix(10)))...
                     SDK Transaction ID: \(String(describing: aReqParams.sdkTransactionID))
                     Message Version: \(String(describing: aReqParams.messageVersion))
                     SDK App ID: \(String(describing: aReqParams.sdkAppID))

--- a/hyperswitch/AuthenticationViewModel.swift
+++ b/hyperswitch/AuthenticationViewModel.swift
@@ -124,8 +124,7 @@ class AuthenticationViewModel: ObservableObject {
                        let ephemeralKeyDict = try? JSONSerialization.jsonObject(with: ephemeralKeyData, options: []) as? [String: Any] {
                         var stringifiedDict: [String: String] = [:]
                         for (key, value) in ephemeralKeyDict {
-                            let _key = key.prefix(1).uppercased() + key.dropFirst()
-                            stringifiedDict[_key] = String(describing: value)
+                            stringifiedDict[key] = String(describing: value)
                         }
                         ephemeralPublicKey = stringifiedDict
                     }

--- a/hyperswitchSDK/AuthenticationModule/ThreeDS/Providers/CardinalProvider.swift
+++ b/hyperswitchSDK/AuthenticationModule/ThreeDS/Providers/CardinalProvider.swift
@@ -115,12 +115,11 @@ class CardinalTransactionProvider: ThreeDSTransactionProvider {
         } else {
             return AuthenticationRequestParameters(
                 sdkTransactionID: nil,
-                deviceData: nil,
+                deviceData: cardinalEncryptedData,
                 sdkEphemeralPublicKey: nil,
                 sdkAppID: nil,
                 sdkReferenceNumber: nil,
-                messageVersion: nil,
-                sdkEncryptedData: cardinalEncryptedData
+                messageVersion: nil
             )
         }
     }

--- a/hyperswitchSDK/AuthenticationModule/ThreeDS/Providers/NetceteraProvider.swift
+++ b/hyperswitchSDK/AuthenticationModule/ThreeDS/Providers/NetceteraProvider.swift
@@ -72,8 +72,7 @@ class NetceteraTransactionProvider: ThreeDSTransactionProvider {
             sdkEphemeralPublicKey: netceteraParams.getSDKEphemeralPublicKey(),
             sdkAppID: netceteraParams.getSDKAppID(),
             sdkReferenceNumber: netceteraParams.getSDKReferenceNumber(),
-            messageVersion: netceteraParams.getMessageVersion(),
-            sdkEncryptedData: nil
+            messageVersion: netceteraParams.getMessageVersion()
         )
     }
     

--- a/hyperswitchSDK/AuthenticationModule/ThreeDS/Providers/TridentProvider.swift
+++ b/hyperswitchSDK/AuthenticationModule/ThreeDS/Providers/TridentProvider.swift
@@ -67,8 +67,7 @@ class TridentTransactionProvider: ThreeDSTransactionProvider {
             sdkEphemeralPublicKey: aReqParams.sdkEphemeralPublicKey,
             sdkAppID: aReqParams.sdkAppID,
             sdkReferenceNumber: aReqParams.sdkReferenceNumber,
-            messageVersion: aReqParams.messageVersion,
-            sdkEncryptedData: nil
+            messageVersion: aReqParams.messageVersion
         )
     }
     

--- a/hyperswitchSDK/AuthenticationModule/ThreeDS/Transaction.swift
+++ b/hyperswitchSDK/AuthenticationModule/ThreeDS/Transaction.swift
@@ -62,7 +62,6 @@ public class AuthenticationRequestParameters {
     final public let sdkAppID: String?
     final public let sdkReferenceNumber: String?
     final public let messageVersion: String?
-    final public let sdkEncryptedData: String?
     
     init(
         sdkTransactionID: String?,
@@ -70,8 +69,7 @@ public class AuthenticationRequestParameters {
         sdkEphemeralPublicKey: String?,
         sdkAppID: String?,
         sdkReferenceNumber: String?,
-        messageVersion: String?,
-        sdkEncryptedData: String?
+        messageVersion: String?
     ) {
         self.deviceData = deviceData
         self.sdkTransactionID = sdkTransactionID
@@ -79,7 +77,6 @@ public class AuthenticationRequestParameters {
         self.sdkAppID = sdkAppID
         self.sdkReferenceNumber = sdkReferenceNumber
         self.messageVersion = messageVersion
-        self.sdkEncryptedData = sdkEncryptedData
     }
 }
 


### PR DESCRIPTION
## FIXED
- Removed `sdkEncryptedData` (required for Cardinal) from aReqParams, as that can be consilodated into already existing `deviceData` in areqParams.
- payload for ephemeral key in demo app's authentication module for three ds flows.