### PR TITLE
feat: added support for layout types

### DIFF
--- a/hyperswitch/ViewController.swift
+++ b/hyperswitch/ViewController.swift
@@ -62,6 +62,15 @@ class ViewController: UIViewController {
         appearance.colors.background = UIColor(red: 0.96, green: 0.97, blue: 0.98, alpha: 1.00)
         appearance.colors.primary = UIColor(red: 0.55, green: 0.74, blue: 0.00, alpha: 1.00)
         appearance.primaryButton.cornerRadius = 32
+        
+        appearance.layout = PaymentSheet.Appearance.Layout(
+            type: .tabs,
+            showOneClickWalletsOnTop: true,
+            paymentMethodsArrangementForTabs: .default,
+            defaultCollapsed:false,
+            spacedAccordionItems:false
+        )
+        
         configuration.appearance = appearance
         if let netceteraApiKey = hyperViewModel.netceteraApiKey {
             configuration.netceteraSDKApiKey = netceteraApiKey

--- a/hyperswitch/ViewController.swift
+++ b/hyperswitch/ViewController.swift
@@ -63,13 +63,7 @@ class ViewController: UIViewController {
         appearance.colors.primary = UIColor(red: 0.55, green: 0.74, blue: 0.00, alpha: 1.00)
         appearance.primaryButton.cornerRadius = 32
         
-        appearance.layout = PaymentSheet.Appearance.Layout(
-            type: .tabs,
-            showOneClickWalletsOnTop: true,
-            paymentMethodsArrangementForTabs: .default,
-            defaultCollapsed:false,
-            spacedAccordionItems:false
-        )
+       appearance.layout = .tabs()
         
         configuration.appearance = appearance
         if let netceteraApiKey = hyperViewModel.netceteraApiKey {

--- a/hyperswitchSDK/Shared/DictionaryConverter.swift
+++ b/hyperswitchSDK/Shared/DictionaryConverter.swift
@@ -76,6 +76,10 @@ extension DictionaryConverter {
                     dictionary[key] = theme.themeLabel
                 }
                 
+                if let layout = element.value as? PaymentSheet.Appearance.Layout {
+                    dictionary[key] = layout.toDictionary()
+                }
+                
                 /// Handle UIColor values
                 if let color = element.value as? UIColor {
                     dictionary[key] = self.hexStringFromColor(color: color)

--- a/hyperswitchSDK/Shared/PaymentSheetAppearance.swift
+++ b/hyperswitchSDK/Shared/PaymentSheetAppearance.swift
@@ -40,6 +40,8 @@ public extension PaymentSheet {
         
         public var theme: Theme?
         
+        public var layout: Layout = Layout()
+        
         public enum Theme: String, Codable {
             case `default` = "Default"
             case light = "Light"
@@ -49,6 +51,116 @@ public extension PaymentSheet {
 
             var themeLabel: String {
                 return self.rawValue
+            }
+        }
+        
+        /// The type of layout used to display payment methods
+        public enum LayoutType: String, Codable {
+            /// Display payment methods in a tabbed interface
+            case tabs = "tabs"
+            /// Display payment methods in an expandable accordion
+            case accordion = "accordion"
+        }
+        
+        /// The arrangement of payment methods in tabs layout
+        public enum PaymentMethodsArrangement: String, Codable {
+            /// Default list arrangement
+            case `default` = "default"
+            /// Grid arrangement
+            case grid = "grid"
+        }
+        
+        /// The grouping behavior for saved payment methods
+        public enum GroupingBehavior: String, Codable {
+            /// Group saved methods by payment method type
+            case groupByPaymentMethods = "groupByPaymentMethods"
+            /// Default grouping behavior
+            case `default` = "default"
+        }
+        
+        /// Customization options for saved payment methods display
+        public struct SavedMethodCustomization: Equatable, DictionaryConverter, Codable {
+            
+            /// Creates a `SavedMethodCustomization` with default values
+            public init() {}
+            
+            /// The grouping behavior for saved payment methods
+            public var groupingBehavior: GroupingBehavior = .default
+            
+            /// Creates a `SavedMethodCustomization` with the specified grouping behavior
+            /// - Parameter groupingBehavior: The grouping behavior to use
+            public init(groupingBehavior: GroupingBehavior = .default) {
+                self.groupingBehavior = groupingBehavior
+            }
+        }
+        
+        // MARK: Layout
+        
+        /// Describes the layout configuration for PaymentSheet
+        public struct Layout: Equatable, DictionaryConverter, Codable {
+            
+            /// Creates a `PaymentSheet.Appearance.Layout` with default values
+            public init() {}
+            
+            /// The type of layout to display payment methods in
+            /// - Note: Can be `.tabs` or `.accordion`. Default is `.tabs`
+            public var type: LayoutType = .tabs
+            
+            /// Whether to show one-click wallets (like Apple Pay) at the top of the payment sheet
+            /// - Note: Default is `true`
+            public var showOneClickWalletsOnTop: Bool = true
+            
+            /// The arrangement of payment methods when using tabs layout
+            /// - Note: Can be `.default` or `.grid`. Default is `.default`
+            public var paymentMethodsArrangementForTabs: PaymentMethodsArrangement = .default
+            
+            /// Whether the accordion should be collapsed by default
+            /// - Note: Only applies when layout type is `.accordion`. Default is `false`
+            public var defaultCollapsed: Bool = false
+            
+            /// Whether to show radio buttons in accordion view
+            /// - Note: Only applies when layout type is `.accordion`. Default is `false`
+            public var radios: Bool = false
+            
+            /// Whether to show spaced accordion items with margins between them
+            /// - Note: Only applies when layout type is `.accordion`. Default is `false`
+            public var spacedAccordionItems: Bool = false
+            
+            /// Maximum number of accordion items to show before collapsing
+            /// - Note: Only applies when layout type is `.accordion`. Default is `4`
+            public var maxAccordionItems: Int = 4
+            
+            /// Customization options for saved payment methods
+            public var savedMethodCustomization: SavedMethodCustomization = SavedMethodCustomization()
+            
+            /// Creates a `Layout` with the specified parameters
+            /// - Parameters:
+            ///   - type: The layout type (tabs or accordion)
+            ///   - showOneClickWalletsOnTop: Whether to show wallets at the top
+            ///   - paymentMethodsArrangementForTabs: Arrangement for tabs layout
+            ///   - defaultCollapsed: Whether accordion is collapsed by default
+            ///   - radios: Whether to show radio buttons
+            ///   - spacedAccordionItems: Whether to space accordion items
+            ///   - maxAccordionItems: Maximum accordion items to show
+            ///   - savedMethodCustomization: Saved method customization options
+            public init(
+                type: LayoutType = .tabs,
+                showOneClickWalletsOnTop: Bool = true,
+                paymentMethodsArrangementForTabs: PaymentMethodsArrangement = .default,
+                defaultCollapsed: Bool = false,
+                radios: Bool = false,
+                spacedAccordionItems: Bool = false,
+                maxAccordionItems: Int = 4,
+                savedMethodCustomization: SavedMethodCustomization = SavedMethodCustomization()
+            ) {
+                self.type = type
+                self.showOneClickWalletsOnTop = showOneClickWalletsOnTop
+                self.paymentMethodsArrangementForTabs = paymentMethodsArrangementForTabs
+                self.defaultCollapsed = defaultCollapsed
+                self.radios = radios
+                self.spacedAccordionItems = spacedAccordionItems
+                self.maxAccordionItems = maxAccordionItems
+                self.savedMethodCustomization = savedMethodCustomization
             }
         }
 

--- a/hyperswitchSDK/Shared/PaymentSheetAppearance.swift
+++ b/hyperswitchSDK/Shared/PaymentSheetAppearance.swift
@@ -54,14 +54,6 @@ public extension PaymentSheet {
             }
         }
         
-        /// The type of layout used to display payment methods
-        public enum LayoutType: String, Codable {
-            /// Display payment methods in a tabbed interface
-            case tabs = "tabs"
-            /// Display payment methods in an expandable accordion
-            case accordion = "accordion"
-        }
-        
         /// The arrangement of payment methods in tabs layout
         public enum PaymentMethodsArrangement: String, Codable {
             /// Default list arrangement
@@ -94,73 +86,53 @@ public extension PaymentSheet {
             }
         }
         
-        // MARK: Layout
-        
-        /// Describes the layout configuration for PaymentSheet
-        public struct Layout: Equatable, DictionaryConverter, Codable {
-            
-            /// Creates a `PaymentSheet.Appearance.Layout` with default values
-            public init() {}
-            
-            /// The type of layout to display payment methods in
-            /// - Note: Can be `.tabs` or `.accordion`. Default is `.tabs`
-            public var type: LayoutType = .tabs
-            
-            /// Whether to show one-click wallets (like Apple Pay) at the top of the payment sheet
-            /// - Note: Default is `true`
-            public var showOneClickWalletsOnTop: Bool = true
-            
-            /// The arrangement of payment methods when using tabs layout
-            /// - Note: Can be `.default` or `.grid`. Default is `.default`
-            public var paymentMethodsArrangementForTabs: PaymentMethodsArrangement = .default
-            
-            /// Whether the accordion should be collapsed by default
-            /// - Note: Only applies when layout type is `.accordion`. Default is `false`
-            public var defaultCollapsed: Bool = false
-            
-            /// Whether to show radio buttons in accordion view
-            /// - Note: Only applies when layout type is `.accordion`. Default is `false`
-            public var radios: Bool = false
-            
-            /// Whether to show spaced accordion items with margins between them
-            /// - Note: Only applies when layout type is `.accordion`. Default is `false`
-            public var spacedAccordionItems: Bool = false
-            
-            /// Maximum number of accordion items to show before collapsing
-            /// - Note: Only applies when layout type is `.accordion`. Default is `4`
-            public var maxAccordionItems: Int = 4
-            
-            /// Customization options for saved payment methods
-            public var savedMethodCustomization: SavedMethodCustomization = SavedMethodCustomization()
-            
-            /// Creates a `Layout` with the specified parameters
-            /// - Parameters:
-            ///   - type: The layout type (tabs or accordion)
-            ///   - showOneClickWalletsOnTop: Whether to show wallets at the top
-            ///   - paymentMethodsArrangementForTabs: Arrangement for tabs layout
-            ///   - defaultCollapsed: Whether accordion is collapsed by default
-            ///   - radios: Whether to show radio buttons
-            ///   - spacedAccordionItems: Whether to space accordion items
-            ///   - maxAccordionItems: Maximum accordion items to show
-            ///   - savedMethodCustomization: Saved method customization options
-            public init(
-                type: LayoutType = .tabs,
+        public enum Layout: Equatable, DictionaryConverter {
+            case tabs(
                 showOneClickWalletsOnTop: Bool = true,
-                paymentMethodsArrangementForTabs: PaymentMethodsArrangement = .default,
+                paymentMethodsArrangement: PaymentMethodsArrangement = .default,
+                savedMethodCustomization: SavedMethodCustomization = SavedMethodCustomization()
+            )
+            
+            case accordion(
+                showOneClickWalletsOnTop: Bool = true,
                 defaultCollapsed: Bool = false,
                 radios: Bool = false,
                 spacedAccordionItems: Bool = false,
                 maxAccordionItems: Int = 4,
                 savedMethodCustomization: SavedMethodCustomization = SavedMethodCustomization()
-            ) {
-                self.type = type
-                self.showOneClickWalletsOnTop = showOneClickWalletsOnTop
-                self.paymentMethodsArrangementForTabs = paymentMethodsArrangementForTabs
-                self.defaultCollapsed = defaultCollapsed
-                self.radios = radios
-                self.spacedAccordionItems = spacedAccordionItems
-                self.maxAccordionItems = maxAccordionItems
-                self.savedMethodCustomization = savedMethodCustomization
+            )
+            
+            public init() {
+                self = .tabs()
+            }
+            
+            public func toDictionary() -> [String: Any] {
+                switch self {
+                case .tabs(let showOneClickWalletsOnTop, let paymentMethodsArrangement, let savedMethodCustomization):
+                    var dict: [String: Any] = [
+                        "type": "tabs",
+                        "showOneClickWalletsOnTop": showOneClickWalletsOnTop,
+                        "paymentMethodsArrangementForTabs": paymentMethodsArrangement.rawValue,
+                        "defaultCollapsed": false,
+                        "radios": false,
+                        "spacedAccordionItems": false,
+                    ]
+                    dict["savedMethodCustomization"] = savedMethodCustomization.toDictionary()
+                    return dict
+                    
+                case .accordion(let showOneClickWalletsOnTop, let defaultCollapsed, let radios, let spacedAccordionItems, let maxAccordionItems, let savedMethodCustomization):
+                    var dict: [String: Any] = [
+                        "type": "accordion",
+                        "showOneClickWalletsOnTop": showOneClickWalletsOnTop,
+                        "paymentMethodsArrangementForTabs": PaymentMethodsArrangement.default.rawValue,
+                        "defaultCollapsed": defaultCollapsed,
+                        "radios": radios,
+                        "spacedAccordionItems": spacedAccordionItems,
+                        "maxAccordionItems": maxAccordionItems,
+                    ]
+                    dict["savedMethodCustomization"] = savedMethodCustomization.toDictionary()
+                    return dict
+                }
             }
         }
 

--- a/hyperswitchSDK/Shared/PaymentSheetAppearance.swift
+++ b/hyperswitchSDK/Shared/PaymentSheetAppearance.swift
@@ -62,19 +62,20 @@ public extension PaymentSheet {
             case grid = "grid"
         }
         
-        /// The grouping behavior for saved payment methods
-        public enum GroupingBehavior: String {
-            /// Group saved methods by payment method type
-            case groupByPaymentMethods = "groupByPaymentMethods"
-            /// Default grouping behavior
-            case `default` = "default"
+        /// Customization options for how saved payment methods are grouped/displayed
+        public struct GroupingBehavior: Equatable, DictionaryConverter {
+            public init() {}
+            /// Whether saved payment methods are shown in a separate screen (default: true)
+            public var displayInSeparateScreen: Bool = true
+            /// Whether saved cards are grouped inside the card tab (default: false)
+            public var groupByPaymentMethods: Bool = false
         }
-        
+
         /// Customization options for saved payment methods display
         public struct SavedMethodCustomization: Equatable, DictionaryConverter {
             public init() {}
             /// The grouping behavior for saved payment methods
-            public var groupingBehavior: GroupingBehavior = .default
+            public var groupingBehavior: GroupingBehavior = GroupingBehavior()
         }
         
         public enum Layout: Equatable, DictionaryConverter {

--- a/hyperswitchSDK/Shared/PaymentSheetAppearance.swift
+++ b/hyperswitchSDK/Shared/PaymentSheetAppearance.swift
@@ -40,7 +40,7 @@ public extension PaymentSheet {
         
         public var theme: Theme?
         
-        public var layout: Layout = Layout()
+        public var layout: Layout?
         
         public enum Theme: String, Codable {
             case `default` = "Default"
@@ -55,7 +55,7 @@ public extension PaymentSheet {
         }
         
         /// The arrangement of payment methods in tabs layout
-        public enum PaymentMethodsArrangement: String, Codable {
+        public enum PaymentMethodsArrangement: String {
             /// Default list arrangement
             case `default` = "default"
             /// Grid arrangement
@@ -63,7 +63,7 @@ public extension PaymentSheet {
         }
         
         /// The grouping behavior for saved payment methods
-        public enum GroupingBehavior: String, Codable {
+        public enum GroupingBehavior: String {
             /// Group saved methods by payment method type
             case groupByPaymentMethods = "groupByPaymentMethods"
             /// Default grouping behavior
@@ -71,19 +71,10 @@ public extension PaymentSheet {
         }
         
         /// Customization options for saved payment methods display
-        public struct SavedMethodCustomization: Equatable, DictionaryConverter, Codable {
-            
-            /// Creates a `SavedMethodCustomization` with default values
+        public struct SavedMethodCustomization: Equatable, DictionaryConverter {
             public init() {}
-            
             /// The grouping behavior for saved payment methods
             public var groupingBehavior: GroupingBehavior = .default
-            
-            /// Creates a `SavedMethodCustomization` with the specified grouping behavior
-            /// - Parameter groupingBehavior: The grouping behavior to use
-            public init(groupingBehavior: GroupingBehavior = .default) {
-                self.groupingBehavior = groupingBehavior
-            }
         }
         
         public enum Layout: Equatable, DictionaryConverter {
@@ -101,10 +92,6 @@ public extension PaymentSheet {
                 maxAccordionItems: Int = 4,
                 savedMethodCustomization: SavedMethodCustomization = SavedMethodCustomization()
             )
-            
-            public init() {
-                self = .tabs()
-            }
             
             public func toDictionary() -> [String: Any] {
                 switch self {


### PR DESCRIPTION
## Description

Adds native iOS API support for structured layout configuration in the Payment Sheet. Merchants can now customize the payment UI layout type, arrangement, and saved method grouping behavior through a typed Swift API.

---

## What's New

- **`PaymentSheet.Appearance.Layout`** — Enum with `.tabs()` and `.accordion()` variants
- **`PaymentMethodsArrangement`** — Enum to switch between `.default` (horizontal scroll) and `.grid` layout (tabs only)
- **`GroupingBehavior`** — Controls whether saved methods are grouped by payment type or shown inline
- **`SavedMethodCustomization`** — Wraps grouping behavior config for saved payment methods
- **Accordion-specific options** — `spacedAccordionItems`, `maxAccordionItems`, `radios`, `defaultCollapsed`
- **DictionaryConverter serialization** — Passes layout config to the React Native bridge

---

## Key Changes

- **`PaymentSheetAppearance.swift`**
  - Added `Layout` enum
  - Added `PaymentMethodsArrangement`
  - Added `GroupingBehavior`
  - Added `SavedMethodCustomization`
  - Wired structured layout config into `PaymentSheet.Appearance`

- **`DictionaryConverter.swift`**
  - Extended serialization to convert `Layout` objects into dictionary format for the JS bridge

- **`ViewController.swift`**
  - Updated demo with `appearance.layout = .tabs()` for validation

---

## Test Cases

Screen recordings are attached for all scenarios below.

| # | Layout | Scenario |
|---|--------|----------|
| 1 | Tabs | Saved methods grouped by payment type |
| 2 | Accordion | Spaced accordion with saved methods grouped |
| 4 | Accordion | Default accordion |
| 5 | Tabs | Default tabs |
| 6 | Accordion | Spaced accordion, no saved method customization |
| 7 | Accordion | Spaced accordion with `maxAccordionItems = 5` |
| 8 | Accordion | Radio buttons with `maxAccordionItems = 5` |
| 9 | Accordion | Radio buttons with `maxAccordionItems = 3` |
| 10 | Tabs | Grid payment methods arrangement |
| 11 | Accordion | Spaced accordion with saved methods inline |
| 12 | Tabs | Saved methods shown inline |

---

## Layout Test Suite for iOS

```swift
var appearance = PaymentSheet.Appearance()

// Test 1 — Tabs + groupByPaymentMethods: true
var grouping1 = PaymentSheet.Appearance.GroupingBehavior()
grouping1.displayInSeparateScreen = false
grouping1.groupByPaymentMethods = true
var savedCustom1 = PaymentSheet.Appearance.SavedMethodCustomization()
savedCustom1.groupingBehavior = grouping1
appearance.layout = .tabs(savedMethodCustomization: savedCustom1)

// Test 2 — Accordion + spacedAccordionItems + groupByPaymentMethods: true
appearance.layout = .accordion(
    spacedAccordionItems: true,
    savedMethodCustomization: savedCustom1
)

// Test 4 — Default Accordion
appearance.layout = .accordion()

// Test 5 — Default Tabs
appearance.layout = .tabs()

// Test 6 — Accordion + spacedAccordionItems
appearance.layout = .accordion(spacedAccordionItems: true)

// Test 7 — Accordion + spacedAccordionItems + maxAccordionItems: 5
appearance.layout = .accordion(
    spacedAccordionItems: true,
    maxAccordionItems: 5
)

// Test 8 — Accordion + spacedAccordionItems + maxAccordionItems: 5 + radios
appearance.layout = .accordion(
    radios: true,
    spacedAccordionItems: true,
    maxAccordionItems: 5,
)

// Test 9 — Accordion + radios + spacedAccordionItems + maxAccordionItems: 3
appearance.layout = .accordion(
    radios: true,
    spacedAccordionItems: true,
    maxAccordionItems: 3
)

// Test 10 — Tabs + Grid arrangement
appearance.layout = .tabs(paymentMethodsArrangement: .grid)

// Test 11 — Accordion + spacedAccordionItems + groupByPaymentMethods: false
var grouping11 = PaymentSheet.Appearance.GroupingBehavior()
grouping11.displayInSeparateScreen = false
grouping11.groupByPaymentMethods = false
var savedCustom11 = PaymentSheet.Appearance.SavedMethodCustomization()
savedCustom11.groupingBehavior = grouping11
appearance.layout = .accordion(
    spacedAccordionItems: true,
    savedMethodCustomization: savedCustom11
)

// Test 12 — Tabs + groupByPaymentMethods: false
appearance.layout = .tabs(savedMethodCustomization: savedCustom11)
```


###Screen Recordings


https://github.com/user-attachments/assets/a64b7e8d-d5e5-4304-85d6-d89ed6ecbc98


https://github.com/user-attachments/assets/55721d50-b1af-4e56-a61d-f50fdf476954


https://github.com/user-attachments/assets/a1aa12cb-f47f-4386-866b-6c9b788b2adf

