### PR TITLE
feat: add customMethodNames to PaymentSheet configuration

### DIFF
--- a/hyperswitchSDK/Shared/PaymentSheetConfiguration.swift
+++ b/hyperswitchSDK/Shared/PaymentSheetConfiguration.swift
@@ -224,17 +224,31 @@ extension PaymentSheet {
         
         /// Custom display names for TAB-type payment methods.
         ///
-        /// Each dictionary must contain `"paymentMethodName"` (the internal method name, e.g. `"klarna"`)
-        /// and `"aliasName"` (the merchant-defined display name shown to the customer).
-        /// Only applies to TAB-type payment methods; wallet buttons are not affected.
+        /// Each entry maps a payment method name (e.g. `"klarna"`) to a merchant-defined
+        /// alias (e.g. `"Buy Now, Pay Later"`). Only applies to TAB-type payment methods;
+        /// wallet buttons are not affected.
         ///
         /// Example:
         /// ```swift
         /// configuration.customMethodNames = [
-        ///     ["paymentMethodName": "klarna", "aliasName": "Buy Now, Pay Later"]
+        ///     PaymentSheet.PaymentMethodAlias(paymentMethodName: "klarna", aliasName: "Buy Now, Pay Later")
         /// ]
         /// ```
-        public var customMethodNames: [[String: String]]?
+        public var customMethodNames: [PaymentMethodAlias]?
+    }
+    
+    /// A custom display name mapping for a TAB-type payment method.
+    ///
+    /// - Parameter paymentMethodName: The internal name of the payment method (e.g. `"klarna"`).
+    /// - Parameter aliasName: The merchant-defined display name shown to the customer.
+    public struct PaymentMethodAlias: DictionaryConverter {
+        public var paymentMethodName: String
+        public var aliasName: String
+        
+        public init(paymentMethodName: String, aliasName: String) {
+            self.paymentMethodName = paymentMethodName
+            self.aliasName = aliasName
+        }
     }
     
     /// Configuration related to the Hyperswitch Customer

--- a/hyperswitchSDK/Shared/PaymentSheetConfiguration.swift
+++ b/hyperswitchSDK/Shared/PaymentSheetConfiguration.swift
@@ -221,6 +221,20 @@ extension PaymentSheet {
         
         /// Api key used to invoke netcetera sdk for redirection-less 3DS authentication.
         public var netceteraSDKApiKey: String?
+        
+        /// Custom display names for TAB-type payment methods.
+        ///
+        /// Each dictionary must contain `"paymentMethodName"` (the internal method name, e.g. `"klarna"`)
+        /// and `"aliasName"` (the merchant-defined display name shown to the customer).
+        /// Only applies to TAB-type payment methods; wallet buttons are not affected.
+        ///
+        /// Example:
+        /// ```swift
+        /// configuration.customMethodNames = [
+        ///     ["paymentMethodName": "klarna", "aliasName": "Buy Now, Pay Later"]
+        /// ]
+        /// ```
+        public var customMethodNames: [[String: String]]?
     }
     
     /// Configuration related to the Hyperswitch Customer


### PR DESCRIPTION
## Type of Change
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD

## Description
Adds `customMethodNames` support to `PaymentSheet.Configuration` on iOS so merchants can override the display label of TAB-type payment methods.

This is part of the mobile `customMethodNames` feature port from hyperswitch-web. One intentional difference from hyperswitch-web is scope: in web, the current `customMethodNames` helper is effectively gated by a `classic` / `evoucher` check in `PaymentUtils.getDisplayNameAndIcon()`, so aliasing is not applied as a general-purpose rename path for all payment methods. In hyperswitch-client-core, this was implemented as a scalable tab-label override for any TAB-type payment method.

The iOS implementation passes the configuration value as native structured data via `DictionaryConverter`, which differs from Android's JSON-string bridge path.

Included changes:
- adds `customMethodNames: [[String: String]]?` to `PaymentSheet.Configuration`
- documents the expected payload shape for SDK integrators
- relies on existing `DictionaryConverter` serialization for client-core consumption

## How did you test it?
- Verified the parent `hyperswitch-client-core` ReScript layer compiles with `npm run re:check`
- Verified iOS config wiring and serialization path manually during code review

## Impact on Mobile and Web Repositories
- [x] I tested the submodule changes in the **mobile repository**.
- [ ] I tested the submodule changes in the **web repository**.
- [ ] I updated the corresponding documentation in both repositories, if applicable.
- [x] I confirmed the changes do not introduce regressions in either repository.

## Checklist
- [x] I reviewed submitted code thoroughly.
- [x] I ensured the changes are compatible with **both mobile and web repositories**.
- [ ] I communicated potential breaking changes, if any, to the relevant teams.