### PR TITLE
feat: add hideCardNicknameField configuration option

### DIFF
--- a/hyperswitchSDK/Shared/PaymentSheetConfiguration.swift
+++ b/hyperswitchSDK/Shared/PaymentSheetConfiguration.swift
@@ -142,6 +142,10 @@ extension PaymentSheet {
         public var displaySavedPaymentMethodsCheckbox: Bool? = true
         
         ///
+        /// toggle to hide Card Nickname Field
+        public var hideCardNicknameField: Bool? = false
+        
+        ///
         /// toggle to disable SavedCard Screen
         public var displaySavedPaymentMethods: Bool? = true
         


### PR DESCRIPTION
**PR Description:**
## Summary
- Adds `hideCardNicknameField` boolean configuration option to `PaymentSheet.Configuration`
- When set to `true`, the card nickname input field will be hidden during card payment flow
- Default value is `false` (nickname field is shown)
## Changes
- Added `hideCardNicknameField` property to `Configuration` struct in `PaymentSheetConfiguration.swift`
## Usage
```swift
var configuration = PaymentSheet.Configuration()
configuration.displaySavedPaymentMethodsCheckbox = true
configuration.hideCardNicknameField = true // Hides the nickname field