### PR TITLE
feat: add savedPaymentMethodsCheckboxCheckedByDefault config prop

### DIFF
--- a/hyperswitchSDK/Shared/PaymentSheetConfiguration.swift
+++ b/hyperswitchSDK/Shared/PaymentSheetConfiguration.swift
@@ -142,6 +142,10 @@ extension PaymentSheet {
         public var displaySavedPaymentMethodsCheckbox: Bool? = true
         
         ///
+        /// When true, the save card details checkbox will be checked by default
+        public var savedPaymentMethodsCheckboxCheckedByDefault: Bool? = false
+        
+        ///
         /// toggle to disable SavedCard Screen
         public var displaySavedPaymentMethods: Bool? = true
         


### PR DESCRIPTION
## Summary
- Add `savedPaymentMethodsCheckboxCheckedByDefault` prop to `PaymentSheet.Configuration`
- When `true`, the save card details checkbox is pre-checked by default
- Defaults to `false`
- Automatically serialized via `DictionaryConverter` protocol reflection