### PR TITLE
fix: make profileId optional in PaymentSession initializer

### DIFF
--- a/hyperswitchSDK/Shared/PaymentSession.swift
+++ b/hyperswitchSDK/Shared/PaymentSession.swift
@@ -23,7 +23,7 @@ public class PaymentSession {
 
     public init(
         publishableKey: String,
-        profileId: String,
+        profileId: String? = nil,
         customBackendUrl: String? = nil,
         customParams: [String: Any]? = nil,
         customLogUrl: String? = nil


### PR DESCRIPTION
 ## Summary
  - Changes `PaymentSession.init`'s `profileId` parameter from `String` to `String? = nil`.
  - No other code changes required — `APIClient.shared.profileId` is already optional storage, and all consumers handle nil gracefully (`?? ""` in `PaymentIntentParams`, `as Any` casts elsewhere).

## Why
- Earlier PR [link to the prior PR that made profileId mandatory](https://github.com/juspay/hyperswitch-sdk-ios/pull/59) tightened the SDK contract to require `profileId` on every merchant integration. After that landed, the product decided `profileId` should be inferred from the publishable key on
   the backend when not explicitly provided — so requiring it from merchants is now a regression on integration ergonomics.

- This PR relaxes the contract back to optional. Merchants who already pass `profileId` see no change. Merchants who don't supply it will have it inferred server-side.
