### PR TITLE
feat: add alwaysSendCustomerAcceptance prop

### DIFF
--- a/hyperswitchSDK/Shared/PaymentSheetConfiguration.swift
+++ b/hyperswitchSDK/Shared/PaymentSheetConfiguration.swift
@@ -64,6 +64,10 @@ extension PaymentSheet {
         public var displaySavedPaymentMethods: Bool? = true
 
         ///
+        /// toggle to always send customer acceptance
+        public var alwaysSendCustomerAcceptance: Bool? = false
+
+        ///
         /// toggle to disable Branding
         public var disableBranding: Bool? = false
 


### PR DESCRIPTION
## ADDED 
#### - `alwaysSendCustomerAcceptance` prop
- boolean option (default: `false`)
- Always sends `customer_acceptance` in payment requests **for non-guest customers**.
- Hides the save card checkbox in SavedPaymentSheet and PaymentSheet