### PR TITLE
feat: add confirm button handling to PaymentWidget and PaymentSheet

### DIFF
--- a/hyperswitch/WidgetViewController.swift
+++ b/hyperswitch/WidgetViewController.swift
@@ -159,7 +159,6 @@ class WidgetViewController: UIViewController {
                     callback(true)
                 }
             }
-
             self.cvcWidget = CVCWidget(
                 configuration: configuration,
                 subscribe: { builder in

--- a/hyperswitchSDK/Core/HyperPaymentWidget/PaymentWidget.swift
+++ b/hyperswitchSDK/Core/HyperPaymentWidget/PaymentWidget.swift
@@ -17,6 +17,8 @@ public class PaymentWidget: UIControl {
     private var rootView: RCTRootView?
     private var initCallback: ((PaymentResult) -> Void)?
     private var shouldProceedWithPaymentCallback: ((String, @escaping (Bool) -> Void) -> Void)?
+    private var confirmCallback: ((PaymentResult) -> Void)?
+    private var onConfirmButtonTriggered: ((String, @escaping (Bool) -> Void) -> Void)?
     private var cancellables = Set<AnyCancellable>()
     internal var paymentEventListener: PaymentEventListener?
     internal var subscribedEventNames: [String] = []
@@ -145,7 +147,20 @@ public class PaymentWidget: UIControl {
             .store(in: &cancellables)
     }
 
-    public func confirm() {
+    public func setOnConfirmButtonTriggered(_ callback: @escaping (String, @escaping (Bool) -> Void) -> Void) {
+        self.onConfirmButtonTriggered = callback
+    }
+
+    internal func notifyConfirmButtonTriggered(payload: String, callback: @escaping (Bool) -> Void) {
+        if(self.onConfirmButtonTriggered == nil){
+            callback(true)
+        }else{
+            self.onConfirmButtonTriggered?(payload, callback)
+        }
+    }
+
+    public func confirm(resolve: @escaping (PaymentResult) -> Void) {
+        self.confirmCallback = resolve
         let payload: [String: Any] = [
             "rootTag": self.widgetReactTag ?? -1,
             "actionType": "CONFIRM_PAYMENT_ACTION",

--- a/hyperswitchSDK/Core/NativeModule/HyperModule.swift
+++ b/hyperswitchSDK/Core/NativeModule/HyperModule.swift
@@ -189,6 +189,23 @@ internal class HyperModule: RCTEventEmitter {
     }
 
     @objc
+    private func onPaymentConfirmButtonClick(_ rootTag: NSNumber, _ payload: String, _ callback: @escaping RCTResponseSenderBlock) {
+        resolveSubscribingTarget(rootTag) { target in
+            if let widget = target as? PaymentWidget {
+                widget.notifyConfirmButtonTriggered(payload: payload) { shouldProceed in
+                    callback([shouldProceed])
+                }
+            } else if let sheet = target as? PaymentSheet {
+                sheet.notifyConfirmButtonTriggered(payload: payload) { shouldProceed in
+                    callback([shouldProceed])
+                }
+            } else {
+                callback([true])
+            }
+        }
+    }
+
+    @objc
     private func exitCardForm(_ rnMessage: String) {
         var response: String?
         var error: NSError?

--- a/hyperswitchSDK/Shared/PaymentSheet.swift
+++ b/hyperswitchSDK/Shared/PaymentSheet.swift
@@ -23,4 +23,18 @@ public class PaymentSheet {
     internal var subscribedEvents: [String] = []
     internal var paymentEventListener: PaymentEventListener?
     internal var shouldProceedWithPaymentCallback: ((String, @escaping (Bool) -> Void) -> Void)?
+
+    private var onConfirmButtonTriggered: ((String, @escaping (Bool) -> Void) -> Void)?
+
+    public func setOnConfirmButtonTriggered(_ callback: @escaping (String, @escaping (Bool) -> Void) -> Void) {
+        self.onConfirmButtonTriggered = callback
+    }
+
+    internal func notifyConfirmButtonTriggered(payload: String, callback: @escaping (Bool) -> Void) {
+        if(self.onConfirmButtonTriggered == nil){
+            callback(true)
+        }else{
+            self.onConfirmButtonTriggered?(payload, callback)
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces a new callback mechanism to allow custom handling of the payment confirmation button in both the `PaymentWidget` and `PaymentSheet` components. This enables clients to intercept the confirmation event, perform additional logic (such as validation or conditional checks), and control whether the payment process should proceed.

**New payment confirmation interception:**

* Added an `onConfirmButtonTriggered` callback property and associated setter (`setOnConfirmButtonTriggered`) to both `PaymentWidget` and `PaymentSheet`, allowing clients to provide logic that determines if the payment should proceed when the confirm button is pressed. [[1]](diffhunk://#diff-79d7d38c13157f9fa4f6ea3afcd7489763aaad58b12214e3c9cec6f25d72d483R19) [[2]](diffhunk://#diff-79d7d38c13157f9fa4f6ea3afcd7489763aaad58b12214e3c9cec6f25d72d483R140-R151) [[3]](diffhunk://#diff-a483b3d4ef8249eaa975e27adf675182ffbac76160135d89f72b7a3b4e14c0dbR25-R37)
* Implemented the `notifyConfirmButtonTriggered` method in both `PaymentWidget` and `PaymentSheet` to invoke the callback if set, or default to allowing the payment to proceed. [[1]](diffhunk://#diff-79d7d38c13157f9fa4f6ea3afcd7489763aaad58b12214e3c9cec6f25d72d483R140-R151) [[2]](diffhunk://#diff-a483b3d4ef8249eaa975e27adf675182ffbac76160135d89f72b7a3b4e14c0dbR25-R37)

**Native module integration:**

* Added a new native module method, `onPaymentConfirmButtonClick`, to `HyperModule` (and its Objective-C interface), which routes the confirm button event to the appropriate widget or sheet and calls the Swift callback, bridging between React Native and native code. [[1]](diffhunk://#diff-ce676af3685831374fedc3b358bdfdb529bb303af4e381260d20480eae437bb9R19) [[2]](diffhunk://#diff-3e4be4535825ca2d84738ed4ec7201e2583534dcb60e781bcc262ffe251270eeR191-R207)

**Testing and usage:**

* Included commented-out example code in `WidgetViewController.swift` showing how to use the new `setOnConfirmButtonTriggered` method to conditionally allow or block confirmation based on the payment method.