### PR TITLE
feat: Restructure component props for improved clarity

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -31,6 +31,15 @@ target 'hyperswitch' do
       :mac_catalyst_enabled => false,
       # :ccache_enabled => true
     )
+
+    # Fix for Xcode 26.4 build error
+    installer.pods_project.targets.each do |target|
+      if target.name == 'fmt'
+        target.build_configurations.each do |config|
+          config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++17'
+        end
+      end
+    end
   end
 end
 

--- a/hyperswitch.xcodeproj/project.pbxproj
+++ b/hyperswitch.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		192F175E42A8AC4EC54D289E /* (null) in Frameworks */ = {isa = PBXBuildFile; };
+		192F175E42A8AC4EC54D289E /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
 		4365207C2C8768B90006C856 /* ApplePayHandlerLite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4365207B2C8768B90006C856 /* ApplePayHandlerLite.swift */; };
 		43E668682C084FB70094BD13 /* montserrat_extralight.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 43E668552C084FB60094BD13 /* montserrat_extralight.ttf */; };
 		43E668692C084FB70094BD13 /* montserrat_bolditalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 43E668562C084FB70094BD13 /* montserrat_bolditalic.ttf */; };
@@ -150,6 +150,7 @@
 		DC5D0115294731480017C67A /* PaymentSheetView+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5D0112294731480017C67A /* PaymentSheetView+SwiftUI.swift */; };
 		DC5D0116294731480017C67A /* PaymentSheetConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5D0113294731480017C67A /* PaymentSheetConfiguration.swift */; };
 		DC5D011E294844900017C67A /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5D011D294844900017C67A /* ViewController.swift */; };
+		DC5D011E2E000001DEMOCFG0 /* DemoConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5D011E2E000000DEMOCFG0 /* DemoConfig.swift */; };
 		DC5D011F2E968D7100185E87 /* AuthenticationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5D011F2E968D7000185E87 /* AuthenticationViewController.swift */; };
 		DC5D0125294847E90017C67A /* PaymentSheetView+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5D0124294847E90017C67A /* PaymentSheetView+UIKit.swift */; };
 		DC5D0127294853A90017C67A /* PaymentSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5D0126294853A90017C67A /* PaymentSheetView.swift */; };
@@ -313,6 +314,7 @@
 		DC5D0112294731480017C67A /* PaymentSheetView+SwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PaymentSheetView+SwiftUI.swift"; sourceTree = "<group>"; };
 		DC5D0113294731480017C67A /* PaymentSheetConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentSheetConfiguration.swift; sourceTree = "<group>"; };
 		DC5D011D294844900017C67A /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		DC5D011E2E000000DEMOCFG0 /* DemoConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoConfig.swift; sourceTree = "<group>"; };
 		DC5D011F2E968D7000185E87 /* AuthenticationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationViewController.swift; sourceTree = "<group>"; };
 		DC5D0124294847E90017C67A /* PaymentSheetView+UIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentSheetView+UIKit.swift"; sourceTree = "<group>"; };
 		DC5D0126294853A90017C67A /* PaymentSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheetView.swift; sourceTree = "<group>"; };
@@ -325,7 +327,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				192F175E42A8AC4EC54D289E /* (null) in Frameworks */,
+				192F175E42A8AC4EC54D289E /* BuildFile in Frameworks */,
 				570D085C0EE0B792AD674EC7 /* libPods-hyperswitch.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -439,6 +441,7 @@
 				79FA101D2F1E93A1006B33CF /* ClickToPayCheckoutViewController.swift */,
 				7901E1CA2EB4DCE2002A9EEE /* ClickToPayViewModel.swift */,
 				DC5D011D294844900017C67A /* ViewController.swift */,
+				DC5D011E2E000000DEMOCFG0 /* DemoConfig.swift */,
 				793451F72F96E7C700416A4B /* WidgetViewController.swift */,
 				790525792BDA73A600D49FE8 /* SwiftUIView.swift */,
 				79728FB82C3412BB00CA8C10 /* HeadlessViewController.swift */,
@@ -826,13 +829,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-hyperswitch/Pods-hyperswitch-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-hyperswitch/Pods-hyperswitch-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -847,13 +846,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-hyperswitch/Pods-hyperswitch-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-hyperswitch/Pods-hyperswitch-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -932,13 +927,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-hyperswitchAppClip/Pods-hyperswitchAppClip-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-hyperswitchAppClip/Pods-hyperswitchAppClip-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1005,6 +996,7 @@
 				792D69F62B95E942001598CD /* ExpressCheckoutLauncher.swift in Sources */,
 				4E69679B2CB7CF71000DBE0A /* PMMViewController.swift in Sources */,
 				DC5D011E294844900017C67A /* ViewController.swift in Sources */,
+				DC5D011E2E000001DEMOCFG0 /* DemoConfig.swift in Sources */,
 				DC5D011F2E968D7100185E87 /* AuthenticationViewController.swift in Sources */,
 				79D474B72CC6FDE80022C47E /* RNResponseHandler.swift in Sources */,
 				4E97AA1E2E992D6A0029501E /* NetworkUtils.swift in Sources */,

--- a/hyperswitch/DemoConfig.swift
+++ b/hyperswitch/DemoConfig.swift
@@ -1,0 +1,227 @@
+//
+//  DemoConfig.swift
+//  Hyperswitch
+//
+//  Reference configuration that mirrors android/demo-app DemoConfig.kt.
+//
+
+import UIKit
+
+// MARK: - Appearance
+
+func buildAppearance() -> PaymentSheet.Appearance {
+    var appearance = PaymentSheet.Appearance()
+
+    // Light colors
+    var colorsLight = PaymentSheet.Appearance.Colors()
+    colorsLight.primary                  = UIColor(hex: "#006DF9")
+    colorsLight.background               = UIColor(hex: "#FFFFFF")
+    colorsLight.componentBackground      = UIColor(hex: "#F6F8F9")
+    colorsLight.componentBorder          = UIColor(hex: "#E0E0E0")
+    colorsLight.componentDivider         = UIColor(hex: "#E0E0E0")
+    colorsLight.componentText            = UIColor(hex: "#000000")
+    colorsLight.text                     = UIColor(hex: "#000000")
+    colorsLight.textSecondary            = UIColor(hex: "#767676")
+    colorsLight.componentPlaceholderText = UIColor(hex: "#9E9E9E")
+    colorsLight.icon                     = UIColor(hex: "#000000")
+    colorsLight.danger                   = UIColor(hex: "#FF0000")
+    colorsLight.loaderBackground         = UIColor(hex: "#F6F8F9")
+    colorsLight.loaderForeground         = UIColor(hex: "#006DF9")
+    appearance.colorsLight = colorsLight
+
+    // Dark colors
+    var colorsDark = PaymentSheet.Appearance.Colors()
+    colorsDark.primary                  = UIColor(hex: "#006DF9")
+    colorsDark.background               = UIColor(hex: "#FFFFFF")
+    colorsDark.componentBackground      = UIColor(hex: "#F6F8F9")
+    colorsDark.componentBorder          = UIColor(hex: "#E0E0E0")
+    colorsDark.componentDivider         = UIColor(hex: "#E0E0E0")
+    colorsDark.componentText            = UIColor(hex: "#000000")
+    colorsDark.text                     = UIColor(hex: "#000000")
+    colorsDark.textSecondary            = UIColor(hex: "#767676")
+    colorsDark.componentPlaceholderText = UIColor(hex: "#9E9E9E")
+    colorsDark.icon                     = UIColor(hex: "#000000")
+    colorsDark.danger                   = UIColor(hex: "#FF0000")
+    colorsDark.loaderBackground         = UIColor(hex: "#F6F8F9")
+    colorsDark.loaderForeground         = UIColor(hex: "#006DF9")
+    appearance.colorsDark = colorsDark
+
+    // Shapes
+    appearance.cornerRadius = 8
+    appearance.borderWidth  = 1
+    var shadow = PaymentSheet.Appearance.Shadow()
+    shadow.color     = UIColor(hex: "#000000")
+    shadow.intensity = 4
+    appearance.shadow = shadow
+
+    // Typography
+    appearance.font.sizeScaleFactor = 1.0
+    appearance.font.family          = "Roboto"
+
+    // Primary button
+    var primaryButtonColorsLight = PaymentSheet.Appearance.PrimaryButtonColors()
+    primaryButtonColorsLight.background = UIColor(hex: "#FFE500")
+    primaryButtonColorsLight.text       = UIColor(hex: "#000000")
+    primaryButtonColorsLight.border     = UIColor(hex: "#000000")
+    appearance.primaryButton.colorsLight = primaryButtonColorsLight
+
+    var primaryButtonColorsDark = PaymentSheet.Appearance.PrimaryButtonColors()
+    primaryButtonColorsDark.background = UIColor(hex: "#FFE500")
+    primaryButtonColorsDark.text       = UIColor(hex: "#000000")
+    primaryButtonColorsDark.border     = UIColor(hex: "#000000")
+    appearance.primaryButton.colorsDark = primaryButtonColorsDark
+
+    appearance.primaryButton.cornerRadius  = 8
+    appearance.primaryButton.borderWidth   = 2.5
+    var primaryButtonShadow = PaymentSheet.Appearance.Shadow()
+    primaryButtonShadow.color     = UIColor(hex: "#000000")
+    primaryButtonShadow.intensity = 4
+    appearance.primaryButton.shadow = primaryButtonShadow
+
+    appearance.theme = .light
+
+    return appearance
+}
+
+// MARK: - Wallet configuration
+
+func buildWallets() -> PaymentSheet.WalletConfiguration {
+    return PaymentSheet.WalletConfiguration(
+        applePay: PaymentSheet.ApplePayWalletConfig(
+            visibility:  .shown,
+            buttonType:  .plain
+        ),
+        payPal: PaymentSheet.PayPalWalletConfig(
+            visibility:  .shown,
+            buttonType:  .paypal,
+            buttonStyle: PaymentSheet.PayPalThemeStyle(light: .gold, dark: .blue)
+        )
+    )
+}
+
+// MARK: - Placeholder
+
+func buildPlaceHolder() -> PaymentSheet.Configuration.PlaceHolder {
+    var placeholder = PaymentSheet.Configuration.PlaceHolder()
+    placeholder.cardNumber = "4242 4242 4242 4242"
+    placeholder.expiryDate = "MM / YY"
+    placeholder.cvv        = "CVC"
+    return placeholder
+}
+
+// MARK: - Address
+
+func buildAddress() -> PaymentSheet.Configuration.Address {
+    var address = PaymentSheet.Configuration.Address()
+    address.city       = "San Francisco"
+    address.country    = "US"
+    address.line1      = "123 Main St"
+    address.line2      = "Apt 4B"
+    address.postalCode = "94102"
+    address.state      = "CA"
+    return address
+}
+
+// MARK: - Billing & shipping
+
+func buildBillingDetails() -> PaymentSheet.Configuration.AddressDetails {
+    var billing = PaymentSheet.Configuration.AddressDetails()
+    billing.address     = buildAddress()
+    billing.email       = "john@example.com"
+    billing.name        = "John Doe"
+    billing.phoneCode   = "91"
+    billing.phoneNumber = "9999999999"
+    return billing
+}
+
+func buildShippingDetails() -> PaymentSheet.Configuration.AddressDetails {
+    var shipping = PaymentSheet.Configuration.AddressDetails()
+    shipping.address     = buildAddress()
+    shipping.name        = "John Doe"
+    shipping.phoneCode   = "91"
+    shipping.phoneNumber = "9999999999"
+    return shipping
+}
+
+// MARK: - Customer
+
+func buildCustomer() -> PaymentSheet.Configuration.CustomerConfiguration {
+    return PaymentSheet.Configuration.CustomerConfiguration(
+        id:                 "cus_xxxxxxxxxxxx",
+        ephemeralKeySecret: "ephem_xxxxxxxxxxxx"
+    )
+}
+
+// MARK: - Payment method layout
+
+func buildPaymentMethodLayout() -> PaymentSheet.PaymentMethodLayout {
+    return PaymentSheet.PaymentMethodLayout(
+        type:                .tabs,
+        radios:              false,
+        maxAccordionItems:   3,
+        spacedAccordionItems: true,
+        defaultCollapsed:    true,
+        savedMethodCustomization: PaymentSheet.SavedMethodCustomization(
+            defaultCollapsed: false,
+            hideCardExpiry:   true,
+            hideCVCError:     false,
+            cvcIcon:          .shown,
+            groupingBehavior: PaymentSheet.GroupingBehavior(
+                displayInSeparateScreen: true,
+                groupByPaymentMethods:   false
+            )
+        )
+    )
+}
+
+// MARK: - Full configuration
+
+/// Builds the demo configuration that mirrors the Android DemoConfig and web DemoAppIndex.js reference.
+///
+/// - Parameter netceteraApiKey: Optional Netcetera 3DS SDK key fetched from the backend.
+func buildDemoConfiguration(netceteraApiKey: String? = nil) -> PaymentSheet.Configuration {
+    var config = PaymentSheet.Configuration()
+
+    config.appearance                                    = buildAppearance()
+    config.walletButtonsConfiguration                    = buildWallets()
+    config.placeholder                                   = buildPlaceHolder()
+    config.defaultBillingDetails                         = buildBillingDetails()
+    config.shippingDetails                               = buildShippingDetails()
+    config.customer                                      = buildCustomer()
+    config.merchantDisplayName                           = "Example, Inc."
+    config.primaryButtonLabel                            = "Pay Now"
+    config.paymentSheetHeaderLabel                       = "Select a payment method"
+    config.savedPaymentSheetHeaderLabel                  = "Saved payment method"
+    config.allowsDelayedPaymentMethods                   = false
+    config.allowsPaymentMethodsRequiringShippingAddress  = false
+    config.displaySavedPaymentMethodsCheckbox            = true
+    config.displaySavedPaymentMethods                    = true
+    config.displayDefaultSavedPaymentIcon                = true
+    config.disableBranding                               = true
+    config.stickyPayButton                               = true
+    config.redirectionInfo                               = .hidden
+    config.paymentMethodOrder                            = ["apple_pay", "google_pay", "paypal", "samsung_pay", "credit", "klarna"]
+    config.paymentMethodsConfig                          = [
+        PaymentSheet.Configuration.PaymentMethodConfig(paymentMethod: "card",   message: ""),
+        PaymentSheet.Configuration.PaymentMethodConfig(paymentMethod: "wallet", message: ""),
+    ]
+    config.paymentMethodLayout                           = buildPaymentMethodLayout()
+    config.netceteraSDKApiKey                            = netceteraApiKey
+
+    return config
+}
+
+// MARK: - UIColor hex helper
+
+private extension UIColor {
+    convenience init(hex: String) {
+        var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        hexSanitized = hexSanitized.hasPrefix("#") ? String(hexSanitized.dropFirst()) : hexSanitized
+        var rgb: UInt64 = 0
+        Scanner(string: hexSanitized).scanHexInt64(&rgb)
+        let r = CGFloat((rgb & 0xFF0000) >> 16) / 255.0
+        let g = CGFloat((rgb & 0x00FF00) >> 8)  / 255.0
+        let b = CGFloat(rgb & 0x0000FF)          / 255.0
+        self.init(red: r, green: g, blue: b, alpha: 1.0)
+    }
+}

--- a/hyperswitch/PMMViewController.swift
+++ b/hyperswitch/PMMViewController.swift
@@ -67,7 +67,9 @@ class PaymentMethodManagementViewController: UIViewController {
         configuration.displaySavedPaymentMethods = false
 
         var appearance = PaymentSheet.Appearance()
-        appearance.colors.background = UIColor(red: 0.96, green: 0.97, blue: 0.98, alpha: 1.00)
+        var lightColors = PaymentSheet.Appearance.Colors()
+        lightColors.background = UIColor(red: 0.96, green: 0.97, blue: 0.98, alpha: 1.00)
+        appearance.colorsLight = lightColors
         appearance.primaryButton.cornerRadius = 32
         configuration.appearance = appearance
 

--- a/hyperswitch/SwiftUIView.swift
+++ b/hyperswitch/SwiftUIView.swift
@@ -69,8 +69,10 @@ struct SwiftUIView: View {
         appearance.font.base = UIFont(name: "montserrat", size: UIFont.systemFontSize)
         appearance.font.sizeScaleFactor = 1.0
         appearance.shadow = .disabled
-        appearance.colors.background = UIColor(red: 0.96, green: 0.97, blue: 0.98, alpha: 1.00)
-        appearance.colors.primary = UIColor(red: 0.55, green: 0.74, blue: 0.00, alpha: 1.00)
+        var lightColors = PaymentSheet.Appearance.Colors()
+        lightColors.background = UIColor(red: 0.96, green: 0.97, blue: 0.98, alpha: 1.00)
+        lightColors.primary = UIColor(red: 0.55, green: 0.74, blue: 0.00, alpha: 1.00)
+        appearance.colorsLight = lightColors
         appearance.primaryButton.cornerRadius = 32
         configuration.appearance = appearance
 

--- a/hyperswitch/ViewController.swift
+++ b/hyperswitch/ViewController.swift
@@ -48,24 +48,7 @@ class ViewController: UIViewController {
 
     @objc
     func openPaymentSheet(_ sender: Any) {
-
-        var configuration = PaymentSheet.Configuration()
-        configuration.primaryButtonLabel = "Purchase ($2.00)"
-        configuration.savedPaymentSheetHeaderLabel = "Payment methods"
-        configuration.paymentSheetHeaderLabel = "Select payment method"
-        configuration.displaySavedPaymentMethods = true
-
-        var appearance = PaymentSheet.Appearance()
-        appearance.font.base = UIFont(name: "montserrat", size: UIFont.systemFontSize)
-        appearance.font.sizeScaleFactor = 1.0
-        appearance.shadow = .disabled
-        appearance.colors.background = UIColor(red: 0.96, green: 0.97, blue: 0.98, alpha: 1.00)
-        appearance.colors.primary = UIColor(red: 0.55, green: 0.74, blue: 0.00, alpha: 1.00)
-        appearance.primaryButton.cornerRadius = 32
-        configuration.appearance = appearance
-        if let netceteraApiKey = hyperViewModel.netceteraApiKey {
-            configuration.netceteraSDKApiKey = netceteraApiKey
-        }
+        let configuration = buildDemoConfiguration(netceteraApiKey: hyperViewModel.netceteraApiKey)
 
         hyperViewModel.paymentSession?.presentPaymentSheet(
             viewController: self,

--- a/hyperswitch/WidgetViewController.swift
+++ b/hyperswitch/WidgetViewController.swift
@@ -130,8 +130,10 @@ class WidgetViewController: UIViewController {
         appearance.font.base = UIFont(name: "montserrat", size: UIFont.systemFontSize)
         appearance.font.sizeScaleFactor = 1.0
         appearance.shadow = .disabled
-        appearance.colors.background = UIColor(red: 0.96, green: 0.97, blue: 0.98, alpha: 1.00)
-        appearance.colors.primary = UIColor(red: 0.55, green: 0.74, blue: 0.00, alpha: 1.00)
+        var lightColors = PaymentSheet.Appearance.Colors()
+        lightColors.background = UIColor(red: 0.96, green: 0.97, blue: 0.98, alpha: 1.00)
+        lightColors.primary = UIColor(red: 0.55, green: 0.74, blue: 0.00, alpha: 1.00)
+        appearance.colorsLight = lightColors
         appearance.primaryButton.cornerRadius = 32
         configuration.appearance = appearance
         if let netceteraApiKey = hyperViewModel.netceteraApiKey {

--- a/hyperswitchAppClip/SwiftUIView.swift
+++ b/hyperswitchAppClip/SwiftUIView.swift
@@ -69,8 +69,10 @@ struct SwiftUIView: View {
         appearance.font.base = UIFont(name: "montserrat", size: UIFont.systemFontSize)
         appearance.font.sizeScaleFactor = 1.0
         appearance.shadow = .disabled
-        appearance.colors.background = UIColor(red: 0.96, green: 0.97, blue: 0.98, alpha: 1.00)
-        appearance.colors.primary = UIColor(red: 0.55, green: 0.74, blue: 0.00, alpha: 1.00)
+        var lightColors = PaymentSheet.Appearance.Colors()
+        lightColors.background = UIColor(red: 0.96, green: 0.97, blue: 0.98, alpha: 1.00)
+        lightColors.primary = UIColor(red: 0.55, green: 0.74, blue: 0.00, alpha: 1.00)
+        appearance.colorsLight = lightColors
         appearance.primaryButton.cornerRadius = 32
         configuration.appearance = appearance
 

--- a/hyperswitchAppClip/ViewController.swift
+++ b/hyperswitchAppClip/ViewController.swift
@@ -89,8 +89,10 @@ class ViewController: UIViewController {
         appearance.font.family = "bitcount single"
         appearance.font.sizeScaleFactor = 1.0
         appearance.shadow = .disabled
-        appearance.colors.background = UIColor(red: 0.96, green: 0.97, blue: 0.98, alpha: 1.00)
-        appearance.colors.primary = UIColor(red: 0.55, green: 0.74, blue: 0.00, alpha: 1.00)
+        var lightColors = PaymentSheet.Appearance.Colors()
+        lightColors.background = UIColor(red: 0.96, green: 0.97, blue: 0.98, alpha: 1.00)
+        lightColors.primary = UIColor(red: 0.55, green: 0.74, blue: 0.00, alpha: 1.00)
+        appearance.colorsLight = lightColors
         appearance.primaryButton.cornerRadius = 32
         configuration.appearance = appearance
 

--- a/hyperswitchSDK/Core/HyperCVCWidget/CVCWidget.swift
+++ b/hyperswitchSDK/Core/HyperCVCWidget/CVCWidget.swift
@@ -55,16 +55,24 @@ public class CVCWidget: UIControl {
         let hyperParams = HyperParams.getHyperParams()
         let nativeConfig = try? configuration?.toDictionary()
 
+        var config: [String: Any] = configurationDict ?? nativeConfig ?? [:]
+        config["subscribedEvents"] = self.subscribedEventNames
+
+        var sdkParams = hyperParams
+        sdkParams["sessionId"] = ""
+        sdkParams["confirm"] = false
+
         let props: [String: Any] = [
-            "configuration": configurationDict ?? nativeConfig as Any,
             "type": "cvcWidget",
-            "publishableKey": APIClient.shared.publishableKey as Any,
-            "profileId": APIClient.shared.profileId as Any,
-            "hyperParams": hyperParams,
+            "hyperswitchConfig": [
+                "publishableKey": APIClient.shared.publishableKey as Any,
+                "profileId": APIClient.shared.profileId as Any,
+            ],
+            "sdkParams": sdkParams,
+            "configuration": config,
             "customBackendUrl": APIClient.shared.customBackendUrl as Any,
             "customLogUrl": APIClient.shared.customLogUrl as Any,
             "customParams": APIClient.shared.customParams as Any,
-            "subscribedEvents": self.subscribedEventNames,
             "from": (configurationDict != nil) ? "rn" : "nativeWidget",
         ]
 

--- a/hyperswitchSDK/Core/HyperExpressCheckout/ExpressCheckoutLauncher.swift
+++ b/hyperswitchSDK/Core/HyperExpressCheckout/ExpressCheckoutLauncher.swift
@@ -57,12 +57,20 @@ public class ExpressCheckoutLauncher {
 
             let hyperParams = HyperParams.getHyperParams()
 
+            var sdkParams = hyperParams
+            sdkParams["sessionId"] = ""
+            sdkParams["confirm"] = false
+
             let props: [String: Any] = [
                 "type": "widgetPayment",
-                "sdkAuthorization": ExpressCheckoutLauncher.sdkAuthorization as Any,
-                "publishableKey": APIClient.shared.publishableKey as Any,
-                "profileId": APIClient.shared.profileId as Any,
-                "hyperParams": hyperParams,
+                "hyperswitchConfig": [
+                    "publishableKey": APIClient.shared.publishableKey as Any,
+                    "profileId": APIClient.shared.profileId as Any,
+                ],
+                "paymentSessionConfig": [
+                    "sdkAuthorization": ExpressCheckoutLauncher.sdkAuthorization as Any,
+                ],
+                "sdkParams": sdkParams,
                 "customBackendUrl": APIClient.shared.customBackendUrl as Any,
                 "customLogUrl": APIClient.shared.customLogUrl as Any,
                 "customParams": APIClient.shared.customParams as Any,

--- a/hyperswitchSDK/Core/HyperPaymentSheet/PaymentSheetView.swift
+++ b/hyperswitchSDK/Core/HyperPaymentSheet/PaymentSheetView.swift
@@ -15,26 +15,31 @@ internal extension PaymentSheet {
     /// Method to get the root view for the payment sheet based on the configured properties.
     func getRootView() -> RCTRootView {
 
-        /// Get the configuration dictionary from the configuration object.
-        let configuration = try? self.configuration?.toDictionary()
+        /// Encode configuration and merge subscribedEvents into it
+        var configuration = (try? self.configuration?.toDictionary()) ?? [:]
+        configuration["subscribedEvents"] = self.subscribedEvents
 
-        /// Create a dictionary of hyperParams with app ID, sdkVersion, country, user agent, default view, and launch time.
-        let hyperParams = HyperParams.getHyperParams()
+        /// Build sdkParams from hyperParams, adding sessionId and confirm
+        var sdkParams = HyperParams.getHyperParams()
+        sdkParams["sessionId"] = ""
+        sdkParams["confirm"] = false
 
-        /// Create a dictionary of props to be sent to React Native with configuration, type, sdkAuthorization, publishable key, hyperParams, custom backend URL, themes, and custom parameters.
+        /// Build props matching the nativeJsonToRecord structure expected by SdkTypes.res
         let props: [String: Any] = [
-            "configuration": configuration as Any,
             "type": "payment",
-            "sdkAuthorization": self.sdkAuthorization,
-            "publishableKey": APIClient.shared.publishableKey as Any,
-            "profileId": APIClient.shared.profileId as Any,
-            "hyperParams": hyperParams,
+            "hyperswitchConfig": [
+                "publishableKey": APIClient.shared.publishableKey as Any,
+                "profileId": APIClient.shared.profileId as Any,
+            ],
+            "paymentSessionConfig": [
+                "sdkAuthorization": self.sdkAuthorization,
+            ],
+            "sdkParams": sdkParams,
+            "configuration": configuration,
             "customBackendUrl": APIClient.shared.customBackendUrl as Any,
             "customLogUrl": APIClient.shared.customLogUrl as Any,
             "customParams": APIClient.shared.customParams as Any,
-            "subscribedEvents": self.subscribedEvents,
         ]
-        /// Get the root view from the RNViewManager with the "hyperSwitch" module and the props dictionary.
         let rootView = RNViewManager.sharedInstance.viewForModule("hyperSwitch", initialProperties: ["props": props])
 
         rootView.backgroundColor = UIColor.clear
@@ -45,19 +50,27 @@ internal extension PaymentSheet {
     /// - Note: Used by Flutter and React Native Wrappers to send separate props.
     func getRootViewWithParams(props: [String: Any]) -> RCTRootView {
 
-        let hyperParams = HyperParams.getHyperParams()
+        var sdkParams = HyperParams.getHyperParams()
+        sdkParams["sessionId"] = ""
+        sdkParams["confirm"] = false
+
+        var configuration = props
+        configuration["subscribedEvents"] = self.subscribedEvents
 
         let props: [String: Any] = [
-            "configuration": props,
             "type": "payment",
-            "sdkAuthorization": self.sdkAuthorization,
-            "publishableKey": APIClient.shared.publishableKey as Any,
-            "profileId": APIClient.shared.profileId as Any,
-            "hyperParams": hyperParams,
+            "hyperswitchConfig": [
+                "publishableKey": APIClient.shared.publishableKey as Any,
+                "profileId": APIClient.shared.profileId as Any,
+            ],
+            "paymentSessionConfig": [
+                "sdkAuthorization": self.sdkAuthorization,
+            ],
+            "sdkParams": sdkParams,
+            "configuration": configuration,
             "customBackendUrl": APIClient.shared.customBackendUrl as Any,
             "customLogUrl": APIClient.shared.customLogUrl as Any,
             "customParams": APIClient.shared.customParams as Any,
-            "subscribedEvents": self.subscribedEvents,
             "from": "rn",
         ]
 

--- a/hyperswitchSDK/Core/HyperPaymentWidget/PaymentWidget.swift
+++ b/hyperswitchSDK/Core/HyperPaymentWidget/PaymentWidget.swift
@@ -70,17 +70,27 @@ public class PaymentWidget: UIControl {
         nativeConfig?["hideConfirmButton"] = true
         configurationDict?["hideConfirmButton"] = true
 
+        var config: [String: Any] = configurationDict ?? nativeConfig ?? [:]
+        config["subscribedEvents"] = self.subscribedEventNames
+
+        var sdkParams = hyperParams
+        sdkParams["sessionId"] = ""
+        sdkParams["confirm"] = false
+
         let props: [String: Any] = [
-            "configuration": configurationDict ?? nativeConfig as Any,
             "type": "widgetPaymentSheet",
-            "sdkAuthorization": paymentSession.sdkAuthorization as Any,
-            "publishableKey": APIClient.shared.publishableKey as Any,
-            "profileId": APIClient.shared.profileId as Any,
-            "hyperParams": hyperParams,
+            "hyperswitchConfig": [
+                "publishableKey": APIClient.shared.publishableKey as Any,
+                "profileId": APIClient.shared.profileId as Any,
+            ],
+            "paymentSessionConfig": [
+                "sdkAuthorization": paymentSession.sdkAuthorization as Any,
+            ],
+            "sdkParams": sdkParams,
+            "configuration": config,
             "customBackendUrl": APIClient.shared.customBackendUrl as Any,
             "customLogUrl": APIClient.shared.customLogUrl as Any,
             "customParams": APIClient.shared.customParams as Any,
-            "subscribedEvents": self.subscribedEventNames,
             "from": (configurationDict != nil) ? "rn" : "nativeWidget",
         ]
 

--- a/hyperswitchSDK/Core/HyperSession/PaymentSession+UIKit.swift
+++ b/hyperswitchSDK/Core/HyperSession/PaymentSession+UIKit.swift
@@ -106,12 +106,20 @@ extension PaymentSession {
         PaymentSession.headlessCompletion = func_
         PaymentSession.activeSession = self
         RNHeadlessManager.sharedInstance.reinvalidateBridge()
-        let hyperParams = HyperParams.getHyperParams()
+
+        var sdkParams = HyperParams.getHyperParams()
+        sdkParams["sessionId"] = ""
+        sdkParams["confirm"] = false
+
         let props: [String: Any] = [
-            "sdkAuthorization": self.sdkAuthorization as Any,
-            "publishableKey": APIClient.shared.publishableKey as Any,
-            "profileId": APIClient.shared.profileId as Any,
-            "hyperParams": hyperParams,
+            "hyperswitchConfig": [
+                "publishableKey": APIClient.shared.publishableKey as Any,
+                "profileId": APIClient.shared.profileId as Any,
+            ],
+            "paymentSessionConfig": [
+                "sdkAuthorization": self.sdkAuthorization as Any,
+            ],
+            "sdkParams": sdkParams,
             "customBackendUrl": APIClient.shared.customBackendUrl as Any,
             "customLogUrl": APIClient.shared.customLogUrl as Any,
             "customParams": APIClient.shared.customParams as Any,

--- a/hyperswitchSDK/CoreLite/PaymentSheetView+Lite.swift
+++ b/hyperswitchSDK/CoreLite/PaymentSheetView+Lite.swift
@@ -14,16 +14,22 @@ extension PaymentSheet {
 
         let configuration = try? self.configuration?.toDictionary()
 
-        let hyperParams = HyperParams.getHyperParams()
+        var sdkParams = HyperParams.getHyperParams()
+        sdkParams["sessionId"] = ""
+        sdkParams["confirm"] = false
 
-        /// Create a dictionary of props to be sent to React Native with configuration, type, client secret, publishable key, hyperParams, custom backend URL, themes, and custom parameters
+        /// Build props matching the nativeJsonToRecord structure expected by SdkTypes.res
         let props: [String: Any] = [
-            "configuration": configuration as Any,
             "type": "payment",
-            "sdkAuthorization": self.sdkAuthorization,
-            "publishableKey": APIClient.shared.publishableKey as Any,
-            "profileId": APIClient.shared.profileId as Any,
-            "hyperParams": hyperParams,
+            "hyperswitchConfig": [
+                "publishableKey": APIClient.shared.publishableKey as Any,
+                "profileId": APIClient.shared.profileId as Any,
+            ],
+            "paymentSessionConfig": [
+                "sdkAuthorization": self.sdkAuthorization,
+            ],
+            "sdkParams": sdkParams,
+            "configuration": configuration as Any,
             "customBackendUrl": APIClient.shared.customBackendUrl as Any,
             "customLogUrl": APIClient.shared.customLogUrl as Any,
             "customParams": APIClient.shared.customParams as Any,

--- a/hyperswitchSDK/Shared/PaymentSheetAppearance+Codable.swift
+++ b/hyperswitchSDK/Shared/PaymentSheetAppearance+Codable.swift
@@ -11,8 +11,8 @@ import UIKit
 extension PaymentSheet.Appearance.Colors: Codable {
     enum CodingKeys: String, CodingKey {
         case primary, background, componentBackground, componentBorder
-        case componentDivider, text, textSecondary, componentText
-        case componentPlaceholderText, icon, danger
+        case componentDivider, primaryText, secondaryText, componentText
+        case placeholderText, icon, error
         case loaderBackground, loaderForeground
     }
 
@@ -23,12 +23,12 @@ extension PaymentSheet.Appearance.Colors: Codable {
         try c.encodeIfPresent(componentBackground.map { CodableColor($0) }, forKey: .componentBackground)
         try c.encodeIfPresent(componentBorder.map { CodableColor($0) }, forKey: .componentBorder)
         try c.encodeIfPresent(componentDivider.map { CodableColor($0) }, forKey: .componentDivider)
-        try c.encodeIfPresent(text.map { CodableColor($0) }, forKey: .text)
-        try c.encodeIfPresent(textSecondary.map { CodableColor($0) }, forKey: .textSecondary)
+        try c.encodeIfPresent(text.map { CodableColor($0) }, forKey: .primaryText)
+        try c.encodeIfPresent(textSecondary.map { CodableColor($0) }, forKey: .secondaryText)
         try c.encodeIfPresent(componentText.map { CodableColor($0) }, forKey: .componentText)
-        try c.encodeIfPresent(componentPlaceholderText.map { CodableColor($0) }, forKey: .componentPlaceholderText)
+        try c.encodeIfPresent(componentPlaceholderText.map { CodableColor($0) }, forKey: .placeholderText)
         try c.encodeIfPresent(icon.map { CodableColor($0) }, forKey: .icon)
-        try c.encodeIfPresent(danger.map { CodableColor($0) }, forKey: .danger)
+        try c.encodeIfPresent(danger.map { CodableColor($0) }, forKey: .error)
         try c.encodeIfPresent(loaderBackground.map { CodableColor($0) }, forKey: .loaderBackground)
         try c.encodeIfPresent(loaderForeground.map { CodableColor($0) }, forKey: .loaderForeground)
     }
@@ -41,12 +41,12 @@ extension PaymentSheet.Appearance.Colors: Codable {
         componentBackground = try c.decodeIfPresent(CodableColor.self, forKey: .componentBackground)?.uiColor
         componentBorder = try c.decodeIfPresent(CodableColor.self, forKey: .componentBorder)?.uiColor
         componentDivider = try c.decodeIfPresent(CodableColor.self, forKey: .componentDivider)?.uiColor
-        text = try c.decodeIfPresent(CodableColor.self, forKey: .text)?.uiColor
-        textSecondary = try c.decodeIfPresent(CodableColor.self, forKey: .textSecondary)?.uiColor
+        text = try c.decodeIfPresent(CodableColor.self, forKey: .primaryText)?.uiColor
+        textSecondary = try c.decodeIfPresent(CodableColor.self, forKey: .secondaryText)?.uiColor
         componentText = try c.decodeIfPresent(CodableColor.self, forKey: .componentText)?.uiColor
-        componentPlaceholderText = try c.decodeIfPresent(CodableColor.self, forKey: .componentPlaceholderText)?.uiColor
+        componentPlaceholderText = try c.decodeIfPresent(CodableColor.self, forKey: .placeholderText)?.uiColor
         icon = try c.decodeIfPresent(CodableColor.self, forKey: .icon)?.uiColor
-        danger = try c.decodeIfPresent(CodableColor.self, forKey: .danger)?.uiColor
+        danger = try c.decodeIfPresent(CodableColor.self, forKey: .error)?.uiColor
         loaderBackground = try c.decodeIfPresent(CodableColor.self, forKey: .loaderBackground)?.uiColor
         loaderForeground = try c.decodeIfPresent(CodableColor.self, forKey: .loaderForeground)?.uiColor
     }
@@ -54,14 +54,14 @@ extension PaymentSheet.Appearance.Colors: Codable {
 
 extension PaymentSheet.Appearance.Font: Codable {
     enum CodingKeys: String, CodingKey {
-        case sizeScaleFactor, base, headingTextSizeAdjust, subHeadingTextSizeAdjust
+        case scale, base, headingTextSizeAdjust, subHeadingTextSizeAdjust
         case placeholderTextSizeAdjust, buttonTextSizeAdjust, errorTextSizeAdjust
         case linkTextSizeAdjust, modalTextSizeAdjust, cardTextSizeAdjust, family
     }
 
     public func encode(to encoder: Encoder) throws {
         var c = encoder.container(keyedBy: CodingKeys.self)
-        try c.encodeIfPresent(sizeScaleFactor, forKey: .sizeScaleFactor)
+        try c.encodeIfPresent(sizeScaleFactor, forKey: .scale)
         try c.encodeIfPresent(base.map { CodableFont($0) }, forKey: .base)
         try c.encodeIfPresent(headingTextSizeAdjust, forKey: .headingTextSizeAdjust)
         try c.encodeIfPresent(subHeadingTextSizeAdjust, forKey: .subHeadingTextSizeAdjust)
@@ -77,7 +77,7 @@ extension PaymentSheet.Appearance.Font: Codable {
     public init(from decoder: Decoder) throws {
         self.init()
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        sizeScaleFactor = try c.decodeIfPresent(CGFloat.self, forKey: .sizeScaleFactor)
+        sizeScaleFactor = try c.decodeIfPresent(CGFloat.self, forKey: .scale)
         base = try c.decodeIfPresent(CodableFont.self, forKey: .base)?.uiFont
         headingTextSizeAdjust = try c.decodeIfPresent(CGFloat.self, forKey: .headingTextSizeAdjust)
         subHeadingTextSizeAdjust = try c.decodeIfPresent(CGFloat.self, forKey: .subHeadingTextSizeAdjust)
@@ -91,21 +91,56 @@ extension PaymentSheet.Appearance.Font: Codable {
     }
 }
 
-extension PaymentSheet.Appearance.PrimaryButton: Codable {
+extension PaymentSheet.Appearance.PrimaryButtonColors: Codable {
     enum CodingKeys: String, CodingKey {
-        case backgroundColor, textColor, successBackgroundColor, successTextColor
-        case cornerRadius, borderColor, borderWidth, font, shadow
+        case background, text, border
     }
 
     public func encode(to encoder: Encoder) throws {
         var c = encoder.container(keyedBy: CodingKeys.self)
-        try c.encodeIfPresent(backgroundColor.map { CodableColor($0) }, forKey: .backgroundColor)
-        try c.encodeIfPresent(textColor.map { CodableColor($0) }, forKey: .textColor)
-        try c.encodeIfPresent(successBackgroundColor.map { CodableColor($0) }, forKey: .successBackgroundColor)
-        try c.encodeIfPresent(successTextColor.map { CodableColor($0) }, forKey: .successTextColor)
-        try c.encodeIfPresent(cornerRadius, forKey: .cornerRadius)
-        try c.encodeIfPresent(borderColor.map { CodableColor($0) }, forKey: .borderColor)
-        try c.encodeIfPresent(borderWidth, forKey: .borderWidth)
+        try c.encodeIfPresent(background.map { CodableColor($0) }, forKey: .background)
+        try c.encodeIfPresent(text.map { CodableColor($0) }, forKey: .text)
+        try c.encodeIfPresent(border.map { CodableColor($0) }, forKey: .border)
+    }
+
+    public init(from decoder: Decoder) throws {
+        self.init()
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        background = try c.decodeIfPresent(CodableColor.self, forKey: .background)?.uiColor
+        text = try c.decodeIfPresent(CodableColor.self, forKey: .text)?.uiColor
+        border = try c.decodeIfPresent(CodableColor.self, forKey: .border)?.uiColor
+    }
+}
+
+extension PaymentSheet.Appearance.PrimaryButton: Codable {
+    // Wire keys that SdkTypes.res parser expects
+    enum CodingKeys: String, CodingKey {
+        case shapes, colors, font, shadow
+    }
+
+    // Sub-key containers used during encode
+    private enum ShapesKeys: String, CodingKey {
+        case borderRadius, borderWidth
+    }
+    private enum ColorsWrapperKeys: String, CodingKey {
+        case light, dark
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+
+        // shapes: { borderRadius, borderWidth }
+        var shapesContainer = c.nestedContainer(keyedBy: ShapesKeys.self, forKey: .shapes)
+        try shapesContainer.encodeIfPresent(cornerRadius, forKey: .borderRadius)
+        try shapesContainer.encodeIfPresent(borderWidth, forKey: .borderWidth)
+
+        // colors: { light: { background, text, border }, dark: { ... } }
+        var colorsContainer = c.nestedContainer(keyedBy: ColorsWrapperKeys.self, forKey: .colors)
+        let light = colorsLight ?? PaymentSheet.Appearance.PrimaryButtonColors()
+        let dark = colorsDark ?? PaymentSheet.Appearance.PrimaryButtonColors()
+        try colorsContainer.encode(light, forKey: .light)
+        try colorsContainer.encode(dark, forKey: .dark)
+
         try c.encodeIfPresent(font.map { CodableFont($0) }, forKey: .font)
         try c.encodeIfPresent(shadow, forKey: .shadow)
     }
@@ -113,13 +148,14 @@ extension PaymentSheet.Appearance.PrimaryButton: Codable {
     public init(from decoder: Decoder) throws {
         self.init()
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        backgroundColor = try c.decodeIfPresent(CodableColor.self, forKey: .backgroundColor)?.uiColor
-        textColor = try c.decodeIfPresent(CodableColor.self, forKey: .textColor)?.uiColor
-        successBackgroundColor = try c.decodeIfPresent(CodableColor.self, forKey: .successBackgroundColor)?.uiColor
-        successTextColor = try c.decodeIfPresent(CodableColor.self, forKey: .successTextColor)?.uiColor
-        cornerRadius = try c.decodeIfPresent(CGFloat.self, forKey: .cornerRadius)
-        borderColor = try c.decodeIfPresent(CodableColor.self, forKey: .borderColor)?.uiColor
-        borderWidth = try c.decodeIfPresent(CGFloat.self, forKey: .borderWidth)
+        if let shapesContainer = try? c.nestedContainer(keyedBy: ShapesKeys.self, forKey: .shapes) {
+            cornerRadius = try shapesContainer.decodeIfPresent(CGFloat.self, forKey: .borderRadius)
+            borderWidth = try shapesContainer.decodeIfPresent(CGFloat.self, forKey: .borderWidth)
+        }
+        if let colorsContainer = try? c.nestedContainer(keyedBy: ColorsWrapperKeys.self, forKey: .colors) {
+            colorsLight = try colorsContainer.decodeIfPresent(PaymentSheet.Appearance.PrimaryButtonColors.self, forKey: .light)
+            colorsDark = try colorsContainer.decodeIfPresent(PaymentSheet.Appearance.PrimaryButtonColors.self, forKey: .dark)
+        }
         font = try c.decodeIfPresent(CodableFont.self, forKey: .font)?.uiFont
         shadow = try c.decodeIfPresent(PaymentSheet.Appearance.Shadow.self, forKey: .shadow)
     }
@@ -151,17 +187,33 @@ extension PaymentSheet.Appearance.Shadow: Codable {
 }
 
 extension PaymentSheet.Appearance: Codable {
+    // Wire keys that SdkTypes.res parser expects
     enum CodingKeys: String, CodingKey {
-        case font, colors, primaryButton, cornerRadius, borderWidth, shadow, theme
+        case font, colors, shapes, primaryButton, shadow, theme
+    }
+
+    private enum ColorsWrapperKeys: String, CodingKey {
+        case light, dark
+    }
+    private enum ShapesKeys: String, CodingKey {
+        case borderRadius, borderWidth
     }
 
     public func encode(to encoder: Encoder) throws {
         var c = encoder.container(keyedBy: CodingKeys.self)
         try c.encodeIfPresent(font, forKey: .font)
-        try c.encodeIfPresent(colors, forKey: .colors)
+
+        // colors: { light: colorsLight, dark: colorsDark }
+        var colorsContainer = c.nestedContainer(keyedBy: ColorsWrapperKeys.self, forKey: .colors)
+        try colorsContainer.encode(colorsLight ?? Colors(), forKey: .light)
+        try colorsContainer.encode(colorsDark ?? Colors(), forKey: .dark)
+
+        // shapes: { borderRadius, borderWidth }
+        var shapesContainer = c.nestedContainer(keyedBy: ShapesKeys.self, forKey: .shapes)
+        try shapesContainer.encodeIfPresent(cornerRadius, forKey: .borderRadius)
+        try shapesContainer.encodeIfPresent(borderWidth, forKey: .borderWidth)
+
         try c.encodeIfPresent(primaryButton, forKey: .primaryButton)
-        try c.encodeIfPresent(cornerRadius, forKey: .cornerRadius)
-        try c.encodeIfPresent(borderWidth, forKey: .borderWidth)
         try c.encodeIfPresent(shadow, forKey: .shadow)
         try c.encodeIfPresent(theme, forKey: .theme)
     }
@@ -170,10 +222,15 @@ extension PaymentSheet.Appearance: Codable {
         self.init()
         let c = try decoder.container(keyedBy: CodingKeys.self)
         font = try c.decodeIfPresent(PaymentSheet.Appearance.Font.self, forKey: .font) ?? Font()
-        colors = try c.decodeIfPresent(PaymentSheet.Appearance.Colors.self, forKey: .colors) ?? Colors()
+        if let colorsContainer = try? c.nestedContainer(keyedBy: ColorsWrapperKeys.self, forKey: .colors) {
+            colorsLight = try colorsContainer.decodeIfPresent(PaymentSheet.Appearance.Colors.self, forKey: .light)
+            colorsDark = try colorsContainer.decodeIfPresent(PaymentSheet.Appearance.Colors.self, forKey: .dark)
+        }
+        if let shapesContainer = try? c.nestedContainer(keyedBy: ShapesKeys.self, forKey: .shapes) {
+            cornerRadius = try shapesContainer.decodeIfPresent(CGFloat.self, forKey: .borderRadius)
+            borderWidth = try shapesContainer.decodeIfPresent(CGFloat.self, forKey: .borderWidth)
+        }
         primaryButton = try c.decodeIfPresent(PaymentSheet.Appearance.PrimaryButton.self, forKey: .primaryButton) ?? PrimaryButton()
-        cornerRadius = try c.decodeIfPresent(CGFloat.self, forKey: .cornerRadius)
-        borderWidth = try c.decodeIfPresent(CGFloat.self, forKey: .borderWidth)
         shadow = try c.decodeIfPresent(PaymentSheet.Appearance.Shadow.self, forKey: .shadow)
         theme = try c.decodeIfPresent(PaymentSheet.Appearance.Theme.self, forKey: .theme)
     }

--- a/hyperswitchSDK/Shared/PaymentSheetAppearance.swift
+++ b/hyperswitchSDK/Shared/PaymentSheetAppearance.swift
@@ -18,9 +18,6 @@ public extension PaymentSheet {
         /// Describes the appearance of fonts in PaymentSheet
         public var font: Font = Font()
 
-        /// Describes the colors in PaymentSheet
-        public var colors: Colors = Colors()
-
         /// Describes the appearance of the primary button (e.g., the "Pay" button)
         public var primaryButton: PrimaryButton = PrimaryButton()
 
@@ -37,6 +34,12 @@ public extension PaymentSheet {
         public var shadow: Shadow?
 
         public var theme: Theme?
+
+        /// The colors used in PaymentSheet in light mode
+        public var colorsLight: Colors?
+
+        /// The colors used in PaymentSheet in dark mode
+        public var colorsDark: Colors?
 
         public enum Theme: String, Codable {
             case `default` = "Default"
@@ -184,6 +187,24 @@ public extension PaymentSheet {
             public var intensity: CGFloat?
         }
 
+        // MARK: Primary Button Colors
+
+        /// Describes the color of the primary button in PaymentSheet
+        public struct PrimaryButtonColors {
+
+            /// Creates a `PaymentSheet.Appearance.PrimaryButtonColors` with default values
+            public init() {}
+
+            /// The background color of the primary button
+            public var background: UIColor?
+
+            /// The text color of the primary button
+            public var text: UIColor?
+
+            /// The border color of the primary button
+            public var border: UIColor?
+        }
+
         // MARK: Primary Button
 
         /// Describes the appearance of the primary button (e.g., the "Pay" button)
@@ -192,8 +213,7 @@ public extension PaymentSheet {
             /// Creates a `PaymentSheet.Appearance.PrimaryButton` with default values
             public init() {}
 
-            /// The background color of the primary button
-            /// - Note: If `nil`, `appearance.colors.primary` will be used as the primary button background color
+            /// The background color of the primary button in light mode (use colorsLight/colorsDark instead)
             public var backgroundColor: UIColor?
 
             /// The text color of the primary button
@@ -230,6 +250,12 @@ public extension PaymentSheet {
             /// The shadow of the primary button
             /// - Note: If `nil`, `appearance.shadow` will be used as the primary button shadow
             public var shadow: Shadow?
+
+            /// The colors of the primary button in light mode
+            public var colorsLight: PrimaryButtonColors?
+
+            /// The colors of the primary button in dark mode
+            public var colorsDark: PrimaryButtonColors?
         }
     }
 }

--- a/hyperswitchSDK/Shared/PaymentSheetConfiguration.swift
+++ b/hyperswitchSDK/Shared/PaymentSheetConfiguration.swift
@@ -9,6 +9,230 @@ import Foundation
 import PassKit
 import UIKit
 
+// MARK: - Wallet Configuration
+extension PaymentSheet {
+
+    /// Visibility of a wallet button
+    public enum WalletShowType: String, Codable {
+        case shown = "shown"
+        case hidden = "hidden"
+    }
+
+    /// Layout type for the payment method list.
+    public enum LayoutType: String, Codable {
+        /// Accordion (expandable list) layout.
+        case accordion = "accordion"
+        /// Tabs layout.
+        case tabs = "tabs"
+    }
+
+    /// Arrangement of payment methods in the tabs layout.
+    public enum PaymentMethodsArrangement: String, Codable {
+        /// Default (list) arrangement.
+        case `default` = "default"
+        /// Grid arrangement.
+        case grid = "grid"
+    }
+
+    // MARK: - Payment Method Layout
+
+    /// Grouping behaviour for saved payment methods in the accordion layout.
+    public struct GroupingBehavior: Codable {
+        public init(
+            displayInSeparateScreen: Bool? = nil,
+            groupByPaymentMethods: Bool? = nil
+        ) {
+            self.displayInSeparateScreen = displayInSeparateScreen
+            self.groupByPaymentMethods = groupByPaymentMethods
+        }
+        public var displayInSeparateScreen: Bool?
+        public var groupByPaymentMethods: Bool?
+    }
+
+    /// Customisation options for the saved payment methods section.
+    public struct SavedMethodCustomization: Codable {
+        public init(
+            defaultCollapsed: Bool? = nil,
+            hideCardExpiry: Bool? = nil,
+            hideCVCError: Bool? = nil,
+            cvcIcon: WalletShowType? = nil,
+            groupingBehavior: GroupingBehavior? = nil
+        ) {
+            self.defaultCollapsed = defaultCollapsed
+            self.hideCardExpiry = hideCardExpiry
+            self.hideCVCError = hideCVCError
+            self.cvcIcon = cvcIcon
+            self.groupingBehavior = groupingBehavior
+        }
+        public var defaultCollapsed: Bool?
+        public var hideCardExpiry: Bool?
+        public var hideCVCError: Bool?
+        public var cvcIcon: WalletShowType?
+        public var groupingBehavior: GroupingBehavior?
+    }
+
+    /// Layout configuration for the payment method list.
+    public struct PaymentMethodLayout: Codable {
+        public init(
+            type: LayoutType? = nil,
+            radios: Bool? = nil,
+            maxAccordionItems: Int? = nil,
+            spacedAccordionItems: Bool? = nil,
+            defaultCollapsed: Bool? = nil,
+            showOneClickWalletsOnTop: Bool? = nil,
+            paymentMethodsArrangementForTabs: PaymentMethodsArrangement? = nil,
+            savedMethodCustomization: SavedMethodCustomization? = nil
+        ) {
+            self.type = type
+            self.radios = radios
+            self.maxAccordionItems = maxAccordionItems
+            self.spacedAccordionItems = spacedAccordionItems
+            self.defaultCollapsed = defaultCollapsed
+            self.showOneClickWalletsOnTop = showOneClickWalletsOnTop
+            self.paymentMethodsArrangementForTabs = paymentMethodsArrangementForTabs
+            self.savedMethodCustomization = savedMethodCustomization
+        }
+        public var type: LayoutType?
+        public var radios: Bool?
+        public var maxAccordionItems: Int?
+        public var spacedAccordionItems: Bool?
+        public var defaultCollapsed: Bool?
+        /// Whether to show one-click wallets at the top of the list (default: true).
+        public var showOneClickWalletsOnTop: Bool?
+        /// Arrangement of payment methods in the tabs layout.
+        public var paymentMethodsArrangementForTabs: PaymentMethodsArrangement?
+        public var savedMethodCustomization: SavedMethodCustomization?
+    }
+
+    // MARK: Apple Pay wallet config
+
+    public enum ApplePayButtonType: String, Codable {
+        case buy = "buy"
+        case setUp = "setUp"
+        case inStore = "inStore"
+        case donate = "donate"
+        case checkout = "checkout"
+        case book = "book"
+        case subscribe = "subscribe"
+        case plain = "plain"
+    }
+
+    public enum ApplePayButtonStyle: String, Codable {
+        case white = "white"
+        case whiteOutline = "whiteOutline"
+        case black = "black"
+    }
+
+    public struct ApplePayThemeStyle: Codable {
+        public init(light: ApplePayButtonStyle = .black, dark: ApplePayButtonStyle = .white) {
+            self.light = light
+            self.dark = dark
+        }
+        public var light: ApplePayButtonStyle
+        public var dark: ApplePayButtonStyle
+    }
+
+    public struct ApplePayWalletConfig: Codable {
+        public init(
+            visibility: WalletShowType = .shown,
+            buttonType: ApplePayButtonType = .plain,
+            buttonStyle: ApplePayThemeStyle? = nil
+        ) {
+            self.visibility = visibility
+            self.buttonType = buttonType
+            self.buttonStyle = buttonStyle
+        }
+        public var visibility: WalletShowType
+        public var buttonType: ApplePayButtonType
+        public var buttonStyle: ApplePayThemeStyle?
+    }
+
+    // MARK: PayPal wallet config
+
+    public enum PayPalButtonType: String, Codable {
+        case paypal = "PAYPAL"
+        case checkout = "CHECKOUT"
+        case buyNow = "BUY_NOW"
+        case pay = "PAY"
+    }
+
+    public enum PayPalButtonStyle: String, Codable {
+        case gold = "GOLD"
+        case blue = "BLUE"
+        case white = "WHITE"
+        case black = "BLACK"
+        case silver = "SILVER"
+    }
+
+    public struct PayPalThemeStyle: Codable {
+        public init(light: PayPalButtonStyle = .gold, dark: PayPalButtonStyle = .blue) {
+            self.light = light
+            self.dark = dark
+        }
+        public var light: PayPalButtonStyle
+        public var dark: PayPalButtonStyle
+    }
+
+    public struct PayPalWalletConfig: Codable {
+        public init(
+            visibility: WalletShowType = .shown,
+            buttonType: PayPalButtonType = .paypal,
+            buttonStyle: PayPalThemeStyle? = nil
+        ) {
+            self.visibility = visibility
+            self.buttonType = buttonType
+            self.buttonStyle = buttonStyle
+        }
+        public var visibility: WalletShowType
+        public var buttonType: PayPalButtonType
+        public var buttonStyle: PayPalThemeStyle?
+    }
+
+    // MARK: Google Pay wallet config (stub — not supported on iOS)
+
+    @available(*, deprecated, message: "Google Pay is not supported on iOS. This type exists only for cross-platform API compatibility.")
+    public struct GooglePayWalletConfig: Codable {
+        public init() {}
+    }
+
+    // MARK: WalletConfiguration
+
+    /// Per-wallet button configuration passed to the payment sheet.
+    /// Google Pay is not supported on iOS and is always hidden.
+    public struct WalletConfiguration: Codable {
+
+        public init(
+            applePay: ApplePayWalletConfig = ApplePayWalletConfig(),
+            payPal: PayPalWalletConfig = PayPalWalletConfig()
+        ) {
+            self.applePay = applePay
+            self.payPal = payPal
+        }
+
+        public var applePay: ApplePayWalletConfig
+        public var payPal: PayPalWalletConfig
+
+        // Wire keys — matches SdkTypes.res: walletButtonsConfiguration { googlePay, applePay, payPal }
+        enum CodingKeys: String, CodingKey {
+            case googlePay, applePay, payPal
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var c = encoder.container(keyedBy: CodingKeys.self)
+            // Google Pay is not supported on iOS — always encode as hidden
+            try c.encode(["visibility": WalletShowType.hidden.rawValue], forKey: .googlePay)
+            try c.encode(applePay, forKey: .applePay)
+            try c.encode(payPal, forKey: .payPal)
+        }
+
+        public init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            applePay = try c.decodeIfPresent(ApplePayWalletConfig.self, forKey: .applePay) ?? ApplePayWalletConfig()
+            payPal = try c.decodeIfPresent(PayPalWalletConfig.self, forKey: .payPal) ?? PayPalWalletConfig()
+        }
+    }
+}
+
 // MARK: - Configuration
 extension PaymentSheet {
 
@@ -87,7 +311,7 @@ extension PaymentSheet {
         /// You can override the default order in which payment methods are displayed in PaymentSheet with a list of payment method types.
         /// See https://docs.hyperswitch.io/api/payment_methods/object#payment_method_object-type for the list of valid types.  You may also pass external payment methods.
         /// - Example: ["card", "external_paypal", "klarna"]
-        /// - Note: If you omit payment methods from this list, they’ll be automatically ordered by Hyperswitch after the ones you provide. Invalid payment methods are ignored.
+        /// - Note: If you omit payment methods from this list, they'll be automatically ordered by Hyperswitch after the ones you provide. Invalid payment methods are ignored.
         public var paymentMethodOrder: [String]?
 
         /// Api key used to invoke netcetera sdk for redirection-less 3DS authentication.
@@ -95,6 +319,138 @@ extension PaymentSheet {
 
         /// hide confirm button for external confirm action
         public var hideConfirmButton: Bool?
+
+        /// Per-wallet button configuration for the payment sheet
+        public var walletButtonsConfiguration: WalletConfiguration = WalletConfiguration()
+
+        /// Controls visibility of redirection info.
+        public var redirectionInfo: WalletShowType?
+
+        /// Layout configuration for the payment method list.
+        public var paymentMethodLayout: PaymentMethodLayout?
+
+        /// The customer configuration (id + ephemeral key).
+        public var customer: CustomerConfiguration?
+
+        /// Whether to display the confirm/pay button.
+        public var displayPayButton: Bool?
+
+        /// Whether to keep the pay button always visible (sticky).
+        public var stickyPayButton: Bool?
+
+        /// Whether to preload the card element before the sheet is opened.
+        public var preloadCardElement: Bool?
+
+        /// Always send customer acceptance data when confirming.
+        public var alwaysSendCustomerAcceptance: Bool?
+
+        /// Automatically open the card scanner when the card form is shown.
+        public var opensCardScannerAutomatically: Bool?
+
+        /// Per-payment-method message overrides.
+        public var paymentMethodsConfig: [PaymentMethodConfig]?
+
+        // MARK: CodingKeys — maps defaultBillingDetails → "billingDetails" on the wire
+        enum CodingKeys: String, CodingKey {
+            case allowsDelayedPaymentMethods
+            case allowsPaymentMethodsRequiringShippingAddress
+            case primaryButtonLabel
+            case paymentSheetHeaderLabel
+            case savedPaymentSheetHeaderLabel
+            case merchantDisplayName
+            case displaySavedPaymentMethodsCheckbox
+            case displaySavedPaymentMethods
+            case disableBranding
+            case placeholder
+            case displayDefaultSavedPaymentIcon
+            case returnURL
+            case defaultView
+            case appearance
+            case billingDetails           // wire key for defaultBillingDetails
+            case shippingDetails
+            case removeSavedPaymentMethodMessage
+            case paymentMethodOrder
+            case netceteraSDKApiKey
+            case hideConfirmButton
+            case walletButtonsConfiguration
+            case redirectionInfo
+            case paymentMethodLayout
+            case customer
+            case displayPayButton
+            case stickyPayButton
+            case preloadCardElement
+            case alwaysSendCustomerAcceptance
+            case opensCardScannerAutomatically
+            case paymentMethodsConfig
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var c = encoder.container(keyedBy: CodingKeys.self)
+            try c.encodeIfPresent(allowsDelayedPaymentMethods, forKey: .allowsDelayedPaymentMethods)
+            try c.encodeIfPresent(allowsPaymentMethodsRequiringShippingAddress, forKey: .allowsPaymentMethodsRequiringShippingAddress)
+            try c.encodeIfPresent(primaryButtonLabel, forKey: .primaryButtonLabel)
+            try c.encodeIfPresent(paymentSheetHeaderLabel, forKey: .paymentSheetHeaderLabel)
+            try c.encodeIfPresent(savedPaymentSheetHeaderLabel, forKey: .savedPaymentSheetHeaderLabel)
+            try c.encodeIfPresent(merchantDisplayName, forKey: .merchantDisplayName)
+            try c.encodeIfPresent(displaySavedPaymentMethodsCheckbox, forKey: .displaySavedPaymentMethodsCheckbox)
+            try c.encodeIfPresent(displaySavedPaymentMethods, forKey: .displaySavedPaymentMethods)
+            try c.encodeIfPresent(disableBranding, forKey: .disableBranding)
+            try c.encode(placeholder, forKey: .placeholder)
+            try c.encodeIfPresent(displayDefaultSavedPaymentIcon, forKey: .displayDefaultSavedPaymentIcon)
+            try c.encodeIfPresent(returnURL, forKey: .returnURL)
+            try c.encodeIfPresent(defaultView, forKey: .defaultView)
+            try c.encode(appearance, forKey: .appearance)
+            try c.encode(defaultBillingDetails, forKey: .billingDetails)
+            try c.encode(shippingDetails, forKey: .shippingDetails)
+            try c.encodeIfPresent(removeSavedPaymentMethodMessage, forKey: .removeSavedPaymentMethodMessage)
+            try c.encodeIfPresent(paymentMethodOrder, forKey: .paymentMethodOrder)
+            try c.encodeIfPresent(netceteraSDKApiKey, forKey: .netceteraSDKApiKey)
+            try c.encodeIfPresent(hideConfirmButton, forKey: .hideConfirmButton)
+            try c.encode(walletButtonsConfiguration, forKey: .walletButtonsConfiguration)
+            try c.encodeIfPresent(redirectionInfo, forKey: .redirectionInfo)
+            try c.encodeIfPresent(paymentMethodLayout, forKey: .paymentMethodLayout)
+            try c.encodeIfPresent(customer, forKey: .customer)
+            try c.encodeIfPresent(displayPayButton, forKey: .displayPayButton)
+            try c.encodeIfPresent(stickyPayButton, forKey: .stickyPayButton)
+            try c.encodeIfPresent(preloadCardElement, forKey: .preloadCardElement)
+            try c.encodeIfPresent(alwaysSendCustomerAcceptance, forKey: .alwaysSendCustomerAcceptance)
+            try c.encodeIfPresent(opensCardScannerAutomatically, forKey: .opensCardScannerAutomatically)
+            try c.encodeIfPresent(paymentMethodsConfig, forKey: .paymentMethodsConfig)
+        }
+
+        public init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            allowsDelayedPaymentMethods = try c.decodeIfPresent(Bool.self, forKey: .allowsDelayedPaymentMethods)
+            allowsPaymentMethodsRequiringShippingAddress = try c.decodeIfPresent(Bool.self, forKey: .allowsPaymentMethodsRequiringShippingAddress)
+            primaryButtonLabel = try c.decodeIfPresent(String.self, forKey: .primaryButtonLabel)
+            paymentSheetHeaderLabel = try c.decodeIfPresent(String.self, forKey: .paymentSheetHeaderLabel)
+            savedPaymentSheetHeaderLabel = try c.decodeIfPresent(String.self, forKey: .savedPaymentSheetHeaderLabel)
+            merchantDisplayName = try c.decodeIfPresent(String.self, forKey: .merchantDisplayName)
+            displaySavedPaymentMethodsCheckbox = try c.decodeIfPresent(Bool.self, forKey: .displaySavedPaymentMethodsCheckbox)
+            displaySavedPaymentMethods = try c.decodeIfPresent(Bool.self, forKey: .displaySavedPaymentMethods)
+            disableBranding = try c.decodeIfPresent(Bool.self, forKey: .disableBranding)
+            placeholder = try c.decodeIfPresent(PlaceHolder.self, forKey: .placeholder) ?? PlaceHolder()
+            displayDefaultSavedPaymentIcon = try c.decodeIfPresent(Bool.self, forKey: .displayDefaultSavedPaymentIcon)
+            returnURL = try c.decodeIfPresent(String.self, forKey: .returnURL)
+            defaultView = try c.decodeIfPresent(Bool.self, forKey: .defaultView)
+            appearance = try c.decodeIfPresent(PaymentSheet.Appearance.self, forKey: .appearance) ?? Appearance()
+            defaultBillingDetails = try c.decodeIfPresent(AddressDetails.self, forKey: .billingDetails) ?? AddressDetails()
+            shippingDetails = try c.decodeIfPresent(AddressDetails.self, forKey: .shippingDetails) ?? AddressDetails()
+            removeSavedPaymentMethodMessage = try c.decodeIfPresent(String.self, forKey: .removeSavedPaymentMethodMessage)
+            paymentMethodOrder = try c.decodeIfPresent([String].self, forKey: .paymentMethodOrder)
+            netceteraSDKApiKey = try c.decodeIfPresent(String.self, forKey: .netceteraSDKApiKey)
+            hideConfirmButton = try c.decodeIfPresent(Bool.self, forKey: .hideConfirmButton)
+            walletButtonsConfiguration = try c.decodeIfPresent(WalletConfiguration.self, forKey: .walletButtonsConfiguration) ?? WalletConfiguration()
+            redirectionInfo = try c.decodeIfPresent(WalletShowType.self, forKey: .redirectionInfo)
+            paymentMethodLayout = try c.decodeIfPresent(PaymentMethodLayout.self, forKey: .paymentMethodLayout)
+            customer = try c.decodeIfPresent(CustomerConfiguration.self, forKey: .customer)
+            displayPayButton = try c.decodeIfPresent(Bool.self, forKey: .displayPayButton)
+            stickyPayButton = try c.decodeIfPresent(Bool.self, forKey: .stickyPayButton)
+            preloadCardElement = try c.decodeIfPresent(Bool.self, forKey: .preloadCardElement)
+            alwaysSendCustomerAcceptance = try c.decodeIfPresent(Bool.self, forKey: .alwaysSendCustomerAcceptance)
+            opensCardScannerAutomatically = try c.decodeIfPresent(Bool.self, forKey: .opensCardScannerAutomatically)
+            paymentMethodsConfig = try c.decodeIfPresent([PaymentMethodConfig].self, forKey: .paymentMethodsConfig)
+        }
 
         public struct PlaceHolder: Codable {
 
@@ -105,6 +461,28 @@ extension PaymentSheet {
             public var expiryDate: String?  //  MM/YY
 
             public var cvv: String?
+        }
+
+        /// Customer identifier + ephemeral key for saved payment methods.
+        public struct CustomerConfiguration: Codable {
+            public init(id: String? = nil, ephemeralKeySecret: String? = nil) {
+                self.id = id
+                self.ephemeralKeySecret = ephemeralKeySecret
+            }
+            public var id: String?
+            public var ephemeralKeySecret: String?
+        }
+
+        /// Per-payment-method message override.
+        public struct PaymentMethodConfig: Codable {
+            public init(paymentMethod: String, message: String? = nil) {
+                self.paymentMethod = paymentMethod
+                self.message = message
+            }
+            /// The payment method identifier, e.g. "card", "wallet".
+            public var paymentMethod: String
+            /// Optional custom message to display for this payment method.
+            public var message: String?
         }
 
         /// Billing details of a customer
@@ -124,8 +502,43 @@ extension PaymentSheet {
             /// - Note: The value set is displayed in the payment sheet as-is. Depending on the payment method, the customer may be required to edit this value.
             public var name: String?
 
-            /// The customer's phone number without formatting (e.g. 5551234567)
-            public var phone: String?
+            /// The customer's phone number (digits only, without country code)
+            public var phoneNumber: String?
+
+            /// The customer's phone country code (e.g. "1" for US, "44" for UK)
+            public var phoneCode: String?
+
+            // MARK: Codable — phone is serialized as { number, code } sub-object
+
+            enum CodingKeys: String, CodingKey {
+                case address, email, name, phone
+            }
+            private enum PhoneKeys: String, CodingKey {
+                case number, code
+            }
+
+            public func encode(to encoder: Encoder) throws {
+                var c = encoder.container(keyedBy: CodingKeys.self)
+                try c.encode(address, forKey: .address)
+                try c.encodeIfPresent(email, forKey: .email)
+                try c.encodeIfPresent(name, forKey: .name)
+                if phoneNumber != nil || phoneCode != nil {
+                    var phoneContainer = c.nestedContainer(keyedBy: PhoneKeys.self, forKey: .phone)
+                    try phoneContainer.encodeIfPresent(phoneNumber, forKey: .number)
+                    try phoneContainer.encodeIfPresent(phoneCode, forKey: .code)
+                }
+            }
+
+            public init(from decoder: Decoder) throws {
+                let c = try decoder.container(keyedBy: CodingKeys.self)
+                address = try c.decodeIfPresent(Address.self, forKey: .address) ?? Address()
+                email = try c.decodeIfPresent(String.self, forKey: .email)
+                name = try c.decodeIfPresent(String.self, forKey: .name)
+                if let phoneContainer = try? c.nestedContainer(keyedBy: PhoneKeys.self, forKey: .phone) {
+                    phoneNumber = try phoneContainer.decodeIfPresent(String.self, forKey: .number)
+                    phoneCode = try phoneContainer.decodeIfPresent(String.self, forKey: .code)
+                }
+            }
         }
 
         /// An address.


### PR DESCRIPTION
This pull request introduces a new reusable demo configuration for the payment sheet, refactors demo and example code to use this shared configuration, and includes some project file maintenance and build fixes. The main goals are to centralize and standardize demo configuration, improve maintainability, and address Xcode build issues.

**Demo configuration refactor and enhancements:**

* Added a new `DemoConfig.swift` file that provides a comprehensive, reusable demo configuration builder (`buildDemoConfiguration`) for the payment sheet, mirroring the Android and web demo configurations. This includes appearance, wallet, placeholders, address, billing/shipping, customer, and payment method layout settings.
* Updated the main demo `ViewController` to use the new `buildDemoConfiguration` function, removing duplicated and hard-coded configuration logic.
* Refactored example/demo view controllers (`PMMViewController.swift`, `WidgetViewController.swift`, `SwiftUIView.swift`, and `hyperswitchAppClip/SwiftUIView.swift`) to use the new `colorsLight` property for appearance settings instead of the deprecated `colors` property, aligning with the new configuration approach. [[1]](diffhunk://#diff-ac890b44ae60e9dcea2a0618e8e9c74bdad70729d018bfc06696ffabc9a54b2fL70-R72) [[2]](diffhunk://#diff-3ba3d8c114e7df885c9e8ba14369562839755891251bd6d9a84cc01701418d1fL72-R75) [[3]](diffhunk://#diff-5fff7e5589362b07c0d1bc603efb3a00e483d403740a9e77c34afd45598f4a26L133-R136) [[4]](diffhunk://#diff-63346338cdaffcc6942795b2c02d6e44851c8e3eda01aea29a6db0ff941beaf0L72-R75)

**Project and build system updates:**

* Added `DemoConfig.swift` to the Xcode project, ensuring it is included in the build and source groups. [[1]](diffhunk://#diff-c39d5712415323ee14107ad14d2c2af8517b72641c6a9b1364f9224addd52c77R153) [[2]](diffhunk://#diff-c39d5712415323ee14107ad14d2c2af8517b72641c6a9b1364f9224addd52c77R317) [[3]](diffhunk://#diff-c39d5712415323ee14107ad14d2c2af8517b72641c6a9b1364f9224addd52c77R444) [[4]](diffhunk://#diff-c39d5712415323ee14107ad14d2c2af8517b72641c6a9b1364f9224addd52c77R999)
* Fixed a build error with the `fmt` pod on Xcode 26.4 by explicitly setting the C++ language standard to C++17 in the `Podfile`.
* Cleaned up project file references and build phase input/output paths for better clarity and maintenance. [[1]](diffhunk://#diff-c39d5712415323ee14107ad14d2c2af8517b72641c6a9b1364f9224addd52c77L10-R10) [[2]](diffhunk://#diff-c39d5712415323ee14107ad14d2c2af8517b72641c6a9b1364f9224addd52c77L328-R330) [[3]](diffhunk://#diff-c39d5712415323ee14107ad14d2c2af8517b72641c6a9b1364f9224addd52c77L829-L836) [[4]](diffhunk://#diff-c39d5712415323ee14107ad14d2c2af8517b72641c6a9b1364f9224addd52c77L850-L857) [[5]](diffhunk://#diff-c39d5712415323ee14107ad14d2c2af8517b72641c6a9b1364f9224addd52c77L935-L942)