### PR TITLE
feat: Saved PM Configuration in Headless

### DIFF
--- a/hyperswitch.xcodeproj/project.pbxproj
+++ b/hyperswitch.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		192F175E42A8AC4EC54D289E /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
+		192F175E42A8AC4EC54D289E /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		4365207C2C8768B90006C856 /* ApplePayHandlerLite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4365207B2C8768B90006C856 /* ApplePayHandlerLite.swift */; };
 		43E668682C084FB70094BD13 /* montserrat_extralight.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 43E668552C084FB60094BD13 /* montserrat_extralight.ttf */; };
 		43E668692C084FB70094BD13 /* montserrat_bolditalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 43E668562C084FB70094BD13 /* montserrat_bolditalic.ttf */; };
@@ -81,6 +81,8 @@
 		790BA8272B99DB5E006678FD /* PaymentSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790BA8262B99DB5E006678FD /* PaymentSession.swift */; };
 		790F847F2D8C311900178A09 /* LogBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790F847D2D8C311900178A09 /* LogBuilder.swift */; };
 		790F84822D8C31E800178A09 /* LogPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790F84812D8C31E500178A09 /* LogPayload.swift */; };
+		791A9A842FBCD46000A8D1EC /* SavedPaymentMethodsConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791A9A832FBCD46000A8D1EC /* SavedPaymentMethodsConfiguration.swift */; };
+		791A9A852FBCD46000A8D1EC /* SavedPaymentMethodsConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791A9A832FBCD46000A8D1EC /* SavedPaymentMethodsConfiguration.swift */; };
 		79232DBF2CA571A900E044E0 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79052A262C89237A0011804E /* Extensions.swift */; };
 		792D69F62B95E942001598CD /* ExpressCheckoutLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792D69F52B95E942001598CD /* ExpressCheckoutLauncher.swift */; };
 		792D69F82B95E94C001598CD /* ExpressCheckoutWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792D69F72B95E94C001598CD /* ExpressCheckoutWidget.swift */; };
@@ -271,6 +273,7 @@
 		790BA8262B99DB5E006678FD /* PaymentSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSession.swift; sourceTree = "<group>"; };
 		790F847D2D8C311900178A09 /* LogBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogBuilder.swift; sourceTree = "<group>"; };
 		790F84812D8C31E500178A09 /* LogPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogPayload.swift; sourceTree = "<group>"; };
+		791A9A832FBCD46000A8D1EC /* SavedPaymentMethodsConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedPaymentMethodsConfiguration.swift; sourceTree = "<group>"; };
 		792D69F52B95E942001598CD /* ExpressCheckoutLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressCheckoutLauncher.swift; sourceTree = "<group>"; };
 		792D69F72B95E94C001598CD /* ExpressCheckoutWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressCheckoutWidget.swift; sourceTree = "<group>"; };
 		792D6A052B99C204001598CD /* HyperHeadless.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HyperHeadless.m; sourceTree = "<group>"; };
@@ -339,7 +342,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				192F175E42A8AC4EC54D289E /* BuildFile in Frameworks */,
+				192F175E42A8AC4EC54D289E /* (null) in Frameworks */,
 				570D085C0EE0B792AD674EC7 /* libPods-hyperswitch.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -613,6 +616,7 @@
 				DC5D0113294731480017C67A /* PaymentSheetConfiguration.swift */,
 				43F6051D2B45FA3300BAA90E /* PaymentSheetAppearance.swift */,
 				79FE014F2E97C22800C5D94A /* PaymentSheetAppearance+Codable.swift */,
+				791A9A832FBCD46000A8D1EC /* SavedPaymentMethodsConfiguration.swift */,
 				79FE014C2E97C18F00C5D94A /* Codable+UIKit.swift */,
 				4E0A93DC2CA2F29500E3A767 /* HyperUIViewController.swift */,
 				663F68FB29CCC93C006E91BD /* APIClient.swift */,
@@ -844,9 +848,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-hyperswitch/Pods-hyperswitch-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-hyperswitch/Pods-hyperswitch-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -861,9 +869,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-hyperswitch/Pods-hyperswitch-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-hyperswitch/Pods-hyperswitch-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -942,9 +954,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-hyperswitchAppClip/Pods-hyperswitchAppClip-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-hyperswitchAppClip/Pods-hyperswitchAppClip-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -958,6 +974,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				791A9A852FBCD46000A8D1EC /* SavedPaymentMethodsConfiguration.swift in Sources */,
 				793451FB2F96EB9F00416A4B /* CVCWidget.swift in Sources */,
 				7954A4472C23A44B00FEC02D /* ApplePayViewManager.m in Sources */,
 				79728FB92C3412BB00CA8C10 /* HeadlessViewController.swift in Sources */,
@@ -1051,6 +1068,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				791A9A842FBCD46000A8D1EC /* SavedPaymentMethodsConfiguration.swift in Sources */,
 				798F8DEC2FBAC16E00765B4C /* PaymentSessionConfiguration.swift in Sources */,
 				75AA28EA2D48F61800CD88A6 /* Environment.swift in Sources */,
 				75AA28EB2D48F61800CD88A6 /* HyperNetworking.swift in Sources */,

--- a/hyperswitchSDK/Core/HyperSession/PaymentSession+UIKit.swift
+++ b/hyperswitchSDK/Core/HyperSession/PaymentSession+UIKit.swift
@@ -73,7 +73,10 @@ extension PaymentSession {
             paymentSheet.presentWithParams(from: viewController, props: params, completion: completion)
         }
 
-    public func getCustomerSavedPaymentMethods(_ func_: @escaping (PaymentSessionHandler) -> Void) {
+    public func getCustomerSavedPaymentMethods(
+        _ func_: @escaping (PaymentSessionHandler) -> Void,
+        configuration: SavedPaymentMethodsConfiguration? = nil
+    ) {
         PaymentSession.hasResponded = false
         PaymentSession.headlessCompletion = func_
         PaymentSession.activeSession = self
@@ -81,12 +84,20 @@ extension PaymentSession {
         let hyperswitchConfiguration = try? hyperswitchConfiguration?.toDictionary()
         let paymentSessionConfiguration = try? paymentSessionConfiguration.toDictionary()
         let sdkParams = SDKParams.getSDKParams()
+        let configurationDict = try? configuration.toDictionary()
 
-        let props: [String: Any] = [
+        var props: [String: Any] = [
             "hyperswitchConfig": hyperswitchConfiguration as Any,
             "paymentSessionConfig": paymentSessionConfiguration as Any,
             "sdkParams": sdkParams,
         ]
+
+        props["configuration"] = [
+            "paymentMethodLayout": [
+                "savedMethodCustomization": configurationDict
+            ]
+        ]
+
         let _ = RNHeadlessManager.sharedInstance.viewForModule("HyperHeadless", initialProperties: ["props": props])
     }
 

--- a/hyperswitchSDK/Shared/PaymentSheetAppearance+Codable.swift
+++ b/hyperswitchSDK/Shared/PaymentSheetAppearance+Codable.swift
@@ -94,7 +94,7 @@ extension PaymentSheet.Appearance.Font: Codable {
 extension PaymentSheet.Appearance.PrimaryButton: Codable {
     enum CodingKeys: String, CodingKey {
         case backgroundColor, textColor, successBackgroundColor, successTextColor
-        case cornerRadius, borderColor, borderWidth, font, shadow
+        case cornerRadius, borderColor, borderWidth, font, shadow, height
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -108,6 +108,7 @@ extension PaymentSheet.Appearance.PrimaryButton: Codable {
         try c.encodeIfPresent(borderWidth, forKey: .borderWidth)
         try c.encodeIfPresent(font.map { CodableFont($0) }, forKey: .font)
         try c.encodeIfPresent(shadow, forKey: .shadow)
+        try c.encodeIfPresent(height, forKey: .height)
     }
 
     public init(from decoder: Decoder) throws {
@@ -122,6 +123,7 @@ extension PaymentSheet.Appearance.PrimaryButton: Codable {
         borderWidth = try c.decodeIfPresent(CGFloat.self, forKey: .borderWidth)
         font = try c.decodeIfPresent(CodableFont.self, forKey: .font)?.uiFont
         shadow = try c.decodeIfPresent(PaymentSheet.Appearance.Shadow.self, forKey: .shadow)
+        height = try c.decodeIfPresent(CGFloat.self, forKey: .height)
     }
 }
 

--- a/hyperswitchSDK/Shared/PaymentSheetAppearance.swift
+++ b/hyperswitchSDK/Shared/PaymentSheetAppearance.swift
@@ -230,6 +230,9 @@ public extension PaymentSheet {
             /// The shadow of the primary button
             /// - Note: If `nil`, `appearance.shadow` will be used as the primary button shadow
             public var shadow: Shadow?
+
+            /// The height of the primary button in points
+            public var height: CGFloat?
         }
     }
 }

--- a/hyperswitchSDK/Shared/SavedPaymentMethodsConfiguration.swift
+++ b/hyperswitchSDK/Shared/SavedPaymentMethodsConfiguration.swift
@@ -1,0 +1,20 @@
+//
+//  SavedPaymentMethodsConfiguration.swift
+//  hyperswitch
+//
+
+import Foundation
+
+/// Configuration for filtering saved payment methods returned by
+/// `PaymentSession.getCustomerSavedPaymentMethods`.
+///
+/// - Parameter hiddenPaymentMethods: Payment method types to exclude from the
+///   saved methods list (e.g. `["apple_pay", "paypal"]`). Values are matched against
+///   the `payment_method_type` field returned by the Hyperswitch API.
+public struct SavedPaymentMethodsConfiguration: Codable {
+    public var hiddenPaymentMethods: [String]
+
+    public init(hiddenPaymentMethods: [String]) {
+        self.hiddenPaymentMethods = hiddenPaymentMethods
+    }
+}


### PR DESCRIPTION
This pull request introduces new configuration options for customizing saved payment methods and the appearance of the primary button in the payment sheet. The main changes include support for filtering saved payment methods, passing this configuration through the session API, and allowing the primary button's height to be set and serialized.

**Saved Payment Methods Customization:**
- Added a new `SavedPaymentMethodsConfiguration` struct to allow filtering of saved payment methods by excluding specified payment method types (e.g., `"apple_pay"`, `"paypal"`). (`hyperswitchSDK/Shared/SavedPaymentMethodsConfiguration.swift`)
- Updated `PaymentSession.getCustomerSavedPaymentMethods` to accept an optional `SavedPaymentMethodsConfiguration` parameter, and modified the method to pass this configuration to the underlying properties if provided. (`hyperswitchSDK/Core/HyperSession/PaymentSession+UIKit.swift`) [[1]](diffhunk://#diff-880fd6e81aa5c8343326467e13f146944188dcdc8e4f6c81ff6f410e1da828b9L76-R79) [[2]](diffhunk://#diff-880fd6e81aa5c8343326467e13f146944188dcdc8e4f6c81ff6f410e1da828b9L85-R99)

**Primary Button Appearance Customization:**
- Added a new `height` property to `PaymentSheet.Appearance.PrimaryButton`, allowing the button height to be customized. (`hyperswitchSDK/Shared/PaymentSheetAppearance.swift`)
- Updated the `Codable` conformance for `PrimaryButton` to include encoding and decoding of the new `height` property. (`hyperswitchSDK/Shared/PaymentSheetAppearance+Codable.swift`) [[1]](diffhunk://#diff-bf2452f87b87869d0e10d4dbe86934d1e5ca995c01ee414458901477c7e2401dL97-R97) [[2]](diffhunk://#diff-bf2452f87b87869d0e10d4dbe86934d1e5ca995c01ee414458901477c7e2401dR111) [[3]](diffhunk://#diff-bf2452f87b87869d0e10d4dbe86934d1e5ca995c01ee414458901477c7e2401dR126)