### PR TITLE
add hideCardNicknameField to PaymentSheet.Configuration

### DIFF
--- a/hyperswitch/SwiftUIView.swift
+++ b/hyperswitch/SwiftUIView.swift
@@ -64,6 +64,7 @@ struct SwiftUIView: View {
         configuration.savedPaymentSheetHeaderLabel = "Payment methods"
         configuration.paymentSheetHeaderLabel = "Select payment method"
         configuration.displaySavedPaymentMethods = true
+        configuration.hideCardNicknameField = false
 
         var appearance = PaymentSheet.Appearance()
         appearance.font.base = UIFont(name: "montserrat", size: UIFont.systemFontSize)

--- a/hyperswitch/ViewController.swift
+++ b/hyperswitch/ViewController.swift
@@ -54,6 +54,7 @@ class ViewController: UIViewController {
         configuration.savedPaymentSheetHeaderLabel = "Payment methods"
         configuration.paymentSheetHeaderLabel = "Select payment method"
         configuration.displaySavedPaymentMethods = true
+        configuration.hideCardNicknameField = false
 
         var appearance = PaymentSheet.Appearance()
         appearance.font.base = UIFont(name: "montserrat", size: UIFont.systemFontSize)

--- a/hyperswitchSDK/Shared/PaymentSheetConfiguration.swift
+++ b/hyperswitchSDK/Shared/PaymentSheetConfiguration.swift
@@ -101,6 +101,9 @@ extension PaymentSheet {
         /// Render card fields (number / expiry / cvc) as separate inputs. Defaults to false.
         public var splitCardFields: Bool?
 
+        /// Hide the card nickname input field regardless of the mandate / save-card state. Defaults to false.
+        public var hideCardNicknameField: Bool?
+
         // MARK: - Placeholder
 
         public struct PlaceHolder: Encodable {


### PR DESCRIPTION
Description:
## What
Exposes `hideCardNicknameField: Bool?` on `PaymentSheet.Configuration`, matching the new
client-core prop.

## How
One property. `Configuration` is `Encodable` with no top-level `CodingKeys` (the only one
in the file is on the nested `Address`, for the snake_case fix), so encoding is
auto-synthesized. `nil` is omitted from the JSON, so the ReScript default of `false` applies
when the merchant does not set it.

Serialization via `Extensions.swift toDictionary()` is generic — no other changes needed.

## Usage
```swift
var configuration = PaymentSheet.Configuration()
configuration.hideCardNicknameField = true
